### PR TITLE
Rersize disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Hardware customization:
 * `RAM` - Amount of RAM in megabytes. Inherited from source VM by default.
 * `RAM_reservation` - Amount of reserved RAM in MB. Inherited from source VM by default.
 * `RAM_reserve_all` - Reserve all available RAM (bool). `false` by default. Cannot be used together with `RAM_reservation`.
+* `disk_size` - Change the disk size (in GB). VM should have a single disk. Cannot be used together with `linked_clone`.
 
 Provisioning:
 * `ssh_username` - [**mandatory**] username in guest OS.

--- a/step_hardware.go
+++ b/step_hardware.go
@@ -14,6 +14,7 @@ type HardwareConfig struct {
 	RAM            int64 `mapstructure:"RAM"`
 	RAMReservation int64 `mapstructure:"RAM_reservation"`
 	RAMReserveAll  bool  `mapstructure:"RAM_reserve_all"`
+	DiskSize       int64 `mapstructure:"disk_size"`
 }
 
 func (c *HardwareConfig) Prepare() []error {
@@ -44,6 +45,7 @@ func (s *StepConfigureHardware) Run(state multistep.StateBag) multistep.StepActi
 			RAM:            s.config.RAM,
 			RAMReservation: s.config.RAMReservation,
 			RAMReserveAll:  s.config.RAMReserveAll,
+			DiskSize:       s.config.DiskSize,
 		})
 		if err != nil {
 			state.Put("error", err)


### PR DESCRIPTION
Closes #8 

Hardware configuration step can optionally alter VM disk size:
```"disk_size": 50```

- Size is specified in gigabytes
- VM should have a single disk
- Cannot be used with linked clones