### PR TITLE
Cluster support

### DIFF
--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -5,30 +5,20 @@ import (
 	"github.com/hashicorp/packer/packer"
 	"fmt"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"github.com/jetbrains-infra/packer-builder-vsphere/common"
 )
 
 type CloneConfig struct {
 	Template     string `mapstructure:"template"`
-	VMName       string `mapstructure:"vm_name"`
-	Folder       string `mapstructure:"folder"`
-	Cluster      string `mapstructure:"cluster"`
-	Host         string `mapstructure:"host"`
-	ResourcePool string `mapstructure:"resource_pool"`
-	Datastore    string `mapstructure:"datastore"`
+	common.VMConfig     `mapstructure:",squash"`
 	LinkedClone  bool   `mapstructure:"linked_clone"`
 }
 
 func (c *CloneConfig) Prepare() []error {
-	var errs []error
+	errs := c.VMConfig.Prepare()
 
 	if c.Template == "" {
 		errs = append(errs, fmt.Errorf("Template name is required"))
-	}
-	if c.VMName == "" {
-		errs = append(errs, fmt.Errorf("Target VM name is required"))
-	}
-	if c.Cluster == "" && c.Host == "" {
-		errs = append(errs, fmt.Errorf("vSphere host or cluster is required"))
 	}
 
 	return errs

--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -11,6 +11,7 @@ type CloneConfig struct {
 	Template     string `mapstructure:"template"`
 	VMName       string `mapstructure:"vm_name"`
 	Folder       string `mapstructure:"folder"`
+	Cluster      string `mapstructure:"cluster"`
 	Host         string `mapstructure:"host"`
 	ResourcePool string `mapstructure:"resource_pool"`
 	Datastore    string `mapstructure:"datastore"`
@@ -26,8 +27,8 @@ func (c *CloneConfig) Prepare() []error {
 	if c.VMName == "" {
 		errs = append(errs, fmt.Errorf("Target VM name is required"))
 	}
-	if c.Host == "" {
-		errs = append(errs, fmt.Errorf("vSphere host is required"))
+	if c.Cluster == "" && c.Host == "" {
+		errs = append(errs, fmt.Errorf("vSphere host or cluster is required"))
 	}
 
 	return errs
@@ -52,6 +53,7 @@ func (s *StepCloneVM) Run(state multistep.StateBag) multistep.StepAction {
 	vm, err := template.Clone(&driver.CloneConfig{
 		Name:         s.config.VMName,
 		Folder:       s.config.Folder,
+		Cluster:	  s.config.Cluster,
 		Host:         s.config.Host,
 		ResourcePool: s.config.ResourcePool,
 		Datastore:    s.config.Datastore,

--- a/common/vm_config.go
+++ b/common/vm_config.go
@@ -1,0 +1,25 @@
+package common
+
+import "fmt"
+
+type VMConfig struct {
+	VMName        string `mapstructure:"vm_name"`
+	Folder        string `mapstructure:"folder"`
+	Cluster       string `mapstructure:"cluster"`
+	Host          string `mapstructure:"host"`
+	ResourcePool  string `mapstructure:"resource_pool"`
+	Datastore     string `mapstructure:"datastore"`
+}
+
+func (c *VMConfig) Prepare() []error {
+	var errs []error
+
+	if c.VMName == "" {
+		errs = append(errs, fmt.Errorf("Target VM name is required"))
+	}
+	if c.Cluster == "" && c.Host == "" {
+		errs = append(errs, fmt.Errorf("vSphere host or cluster is required"))
+	}
+
+	return errs
+}

--- a/driver/host.go
+++ b/driver/host.go
@@ -4,7 +4,6 @@ import (
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vim25/mo"
-	"fmt"
 )
 
 type Host struct {
@@ -20,7 +19,7 @@ func (d *Driver) NewHost(ref *types.ManagedObjectReference) *Host {
 }
 
 func (d *Driver) FindHost(name string) (*Host, error) {
-	h, err := d.finder.HostSystem(d.ctx, fmt.Sprintf("/%v/host/%v", d.datacenter.Name(), name))
+	h, err := d.finder.HostSystem(d.ctx, name)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/resource_pool.go
+++ b/driver/resource_pool.go
@@ -19,8 +19,15 @@ func (d *Driver) NewResourcePool(ref *types.ManagedObjectReference) *ResourcePoo
 	}
 }
 
-func (d *Driver) FindResourcePool(host string, name string) (*ResourcePool, error) {
-	p, err := d.finder.ResourcePool(d.ctx, fmt.Sprintf("/%v/host/%v/Resources/%v", d.datacenter.Name(), host, name))
+func (d *Driver) FindResourcePool(cluster string, host string, name string) (*ResourcePool, error) {
+	var res string
+	if cluster != "" {
+		res = cluster
+	} else {
+		res = host
+	}
+
+	p, err := d.finder.ResourcePool(d.ctx, fmt.Sprintf("%v/Resources/%v", res, name))
 	if err != nil {
 		return nil, err
 	}

--- a/driver/resource_pool_acc_test.go
+++ b/driver/resource_pool_acc_test.go
@@ -6,7 +6,7 @@ func TestResourcePoolAcc(t *testing.T) {
 	initDriverAcceptanceTest(t)
 
 	d := newTestDriver(t)
-	p, err := d.FindResourcePool("esxi-1.vsphere65.test", "pool1/pool2")
+	p, err := d.FindResourcePool("","esxi-1.vsphere65.test", "pool1/pool2")
 	if err != nil {
 		t.Fatalf("Cannot find the default resource pool '%v': %v", "pool1/pool2", err)
 	}

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -18,6 +18,7 @@ type VirtualMachine struct {
 type CloneConfig struct {
 	Name         string
 	Folder       string
+	Cluster 	 string
 	Host         string
 	ResourcePool string
 	Datastore    string
@@ -177,7 +178,7 @@ func (template *VirtualMachine) Clone(config *CloneConfig) (*VirtualMachine, err
 
 	var relocateSpec types.VirtualMachineRelocateSpec
 
-	pool, err := template.driver.FindResourcePool("", config.Host, config.ResourcePool)
+	pool, err := template.driver.FindResourcePool(config.Cluster, config.Host, config.ResourcePool)
 	if err != nil {
 		return nil, err
 	}

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -16,6 +16,7 @@ type CreateConfig struct {
 
 	VMName        string `mapstructure:"vm_name"`
 	Folder        string `mapstructure:"folder"`
+	Cluster       string `mapstructure:"cluster"`
 	Host          string `mapstructure:"host"`
 	ResourcePool  string `mapstructure:"resource_pool"`
 	Datastore     string `mapstructure:"datastore"`
@@ -38,8 +39,8 @@ func (c *CreateConfig) Prepare() []error {
 	if tmp.VMName == "" {
 		errs = append(errs, fmt.Errorf("Target VM name is required"))
 	}
-	if tmp.Host == "" {
-		errs = append(errs, fmt.Errorf("vSphere host is required"))
+	if tmp.Cluster == "" && tmp.Host == "" {
+		errs = append(errs, fmt.Errorf("vSphere host or cluster is required"))
 	}
 
 	if len(errs) > 0 {
@@ -74,6 +75,7 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 		DiskControllerType:  s.Config.DiskControllerType,
 		Name:                s.Config.VMName,
 		Folder:              s.Config.Folder,
+		Cluster:             s.Config.Cluster,
 		Host:                s.Config.Host,
 		ResourcePool:        s.Config.ResourcePool,
 		Datastore:           s.Config.Datastore,

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -9,17 +9,12 @@ import (
 )
 
 type CreateConfig struct {
+	common.VMConfig `mapstructure:",squash"`
 	common.HardwareConfig `mapstructure:",squash"`
 
 	DiskThinProvisioned bool   `mapstructure:"disk_thin_provisioned"`
 	DiskControllerType  string `mapstructure:"disk_controller_type"`
 
-	VMName        string `mapstructure:"vm_name"`
-	Folder        string `mapstructure:"folder"`
-	Cluster       string `mapstructure:"cluster"`
-	Host          string `mapstructure:"host"`
-	ResourcePool  string `mapstructure:"resource_pool"`
-	Datastore     string `mapstructure:"datastore"`
 	GuestOSType   string `mapstructure:"guest_os_type"`
 	Network       string `mapstructure:"network"`
 	NetworkCard   string `mapstructure:"network_card"`
@@ -33,15 +28,8 @@ func (c *CreateConfig) Prepare() []error {
 	tmp := *c
 
 	// do recursive calls
+	errs = append(errs, tmp.VMConfig.Prepare()...)
 	errs = append(errs, tmp.HardwareConfig.Prepare()...)
-
-	// check for errors
-	if tmp.VMName == "" {
-		errs = append(errs, fmt.Errorf("Target VM name is required"))
-	}
-	if tmp.Cluster == "" && tmp.Host == "" {
-		errs = append(errs, fmt.Errorf("vSphere host or cluster is required"))
-	}
 
 	if len(errs) > 0 {
 		return errs


### PR DESCRIPTION
Fixes #38 
Closes #55 

Resolves errors working with vSphere clusters, both with and without DRS.
Add new `cluster` config parameter.

# Clusters without DRS
require both `cluster` and `host` parameters:
```
"cluster": "cluster1",
"host": "esxi-2.vsphere65.test",
```

# Clusters with DRS
require just `cluster` parameter:
```
"cluster": "cluster2",
```

# Resoruce pools
DRS-enabled clusters may contain resource pools:
```
"cluster": "cluster2",
"resource_pool": "pool1",
```
