### PR TITLE
Add new config option to allow setting virtual machine hardware version

### DIFF
--- a/driver/vm.go
+++ b/driver/vm.go
@@ -53,7 +53,7 @@ type CreateConfig struct {
 	Network       string // "" for default network
 	NetworkCard   string // example: vmxnet3
 	USBController bool
-	Version       string // example: vmx-10
+	Version       int // example: 10
 }
 
 func (d *Driver) NewVM(ref *types.ManagedObjectReference) *VirtualMachine {
@@ -397,7 +397,9 @@ func (config CreateConfig) toConfigSpec() types.VirtualMachineConfigSpec {
 	confSpec.Name = config.Name
 	confSpec.Annotation = config.Annotation
 	confSpec.GuestId = config.GuestOS
-	confSpec.Version = config.Version
+	if config.Version != 0 {
+		confSpec.Version = fmt.Sprintf("%s%d", "vmx-", config.Version)
+	}
 	return confSpec
 }
 

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -53,6 +53,7 @@ type CreateConfig struct {
 	Network       string // "" for default network
 	NetworkCard   string // example: vmxnet3
 	USBController bool
+	Version       string // example: vmx-10
 }
 
 func (d *Driver) NewVM(ref *types.ManagedObjectReference) *VirtualMachine {
@@ -396,6 +397,7 @@ func (config CreateConfig) toConfigSpec() types.VirtualMachineConfigSpec {
 	confSpec.Name = config.Name
 	confSpec.Annotation = config.Annotation
 	confSpec.GuestId = config.GuestOS
+	confSpec.Version = config.Version
 	return confSpec
 }
 

--- a/iso/config.go
+++ b/iso/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/packer/template/interpolate"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
 	"fmt"
-	"regexp"
 )
 
 type Config struct {
@@ -44,9 +43,6 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	}
 	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.CreateConfig.Prepare()...)
-	if matched, _ := regexp.MatchString(`^vmx-\d+$`, c.Version); !matched && c.Version != "" {
-		errs = packer.MultiErrorAppend(errs, fmt.Errorf("'vm_version': " + c.Version + " is not a supported VM version. Valid values start with 'vmx-' and end in a number. Example vmx-10"))
-	}
 
 	if len(errs.Errors) > 0 {
 		return nil, nil, errs

--- a/iso/config.go
+++ b/iso/config.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/packer/template/interpolate"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
 	"fmt"
+	"regexp"
 )
 
 type Config struct {
@@ -43,6 +44,9 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	}
 	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.CreateConfig.Prepare()...)
+	if matched, _ := regexp.MatchString(`^vmx-\d+$`, c.Version); !matched && c.Version != "" {
+		errs = packer.MultiErrorAppend(errs, fmt.Errorf("'vm_version': " + c.Version + " is not a supported VM version. Valid values start with 'vmx-' and end in a number. Example vmx-10"))
+	}
 
 	if len(errs.Errors) > 0 {
 		return nil, nil, errs

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -19,6 +19,7 @@ type CreateConfig struct {
 	Network       string `mapstructure:"network"`
 	NetworkCard   string `mapstructure:"network_card"`
 	USBController bool   `mapstructure:"usb_controller"`
+	Version       string `mapstructure:"vm_version"`
 }
 
 func (c *CreateConfig) Prepare() []error {
@@ -71,6 +72,7 @@ func (s *StepCreateVM) Run(state multistep.StateBag) multistep.StepAction {
 		Network:             s.Config.Network,
 		NetworkCard:         s.Config.NetworkCard,
 		USBController:       s.Config.USBController,
+		Version:             s.Config.Version,
 	})
 
 	if err != nil {

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -19,7 +19,7 @@ type CreateConfig struct {
 	Network       string `mapstructure:"network"`
 	NetworkCard   string `mapstructure:"network_card"`
 	USBController bool   `mapstructure:"usb_controller"`
-	Version       string `mapstructure:"vm_version"`
+	Version       int    `mapstructure:"vm_version"`
 }
 
 func (c *CreateConfig) Prepare() []error {
@@ -31,6 +31,10 @@ func (c *CreateConfig) Prepare() []error {
 	// do recursive calls
 	errs = append(errs, tmp.VMConfig.Prepare()...)
 	errs = append(errs, tmp.HardwareConfig.Prepare()...)
+
+	if tmp.Version < 0 {
+		errs = append(errs, fmt.Errorf("'vm_version' cannot be a negative number"))
+	}
 
 	if len(errs) > 0 {
 		return errs


### PR DESCRIPTION
The vsphere-iso builder gets a new configuration option named
vm_version. It allows setting the VMWare virtual machine hardware
version to a non-default value.

The default behavior remains unchanged. Use the latest supported
hardware version that ESXi/vCenter allows.

VMWare KB for supported virtual machine hardware versions.

https://kb.vmware.com/s/article/1003746