### PR TITLE
Detect datastore automatically

### DIFF
--- a/clone/builder_acc_test.go
+++ b/clone/builder_acc_test.go
@@ -27,7 +27,6 @@ func defaultConfig() map[string]interface{} {
 
 		"template": "alpine",
 		"host":     "esxi-1.vsphere65.test",
-		"datastore": "datastore1",
 
 		"ssh_username": "root",
 		"ssh_password": "jetbrains",

--- a/driver/datastore.go
+++ b/driver/datastore.go
@@ -5,6 +5,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
+	"fmt"
 )
 
 type Datastore struct {
@@ -20,15 +21,34 @@ func (d *Driver) NewDatastore(ref *types.ManagedObjectReference) *Datastore {
 }
 
 // If name is an empty string, returns the default datastore (is exists)
-func (d *Driver) FindDatastore(name string) (*Datastore, error) {
-	ds, err := d.finder.DatastoreOrDefault(d.ctx, name)
-	if err != nil {
-		return nil, err
+func (d *Driver) FindDatastore(name string, host string) (*Datastore, error) {
+	if name != "" {
+		ds, err := d.finder.Datastore(d.ctx, name)
+		if err != nil {
+			return nil, err
+		}
+
+		return &Datastore{
+			ds:     ds,
+			driver: d,
+		}, nil
+	} else {
+		h, err := d.FindHost(host)
+		if err != nil {
+			return nil, err
+		}
+
+		i, err := h.Info("datastore")
+		if err != nil {
+			return nil, err
+		}
+
+		if len (i.Datastore) != 1 {
+			return nil, fmt.Errorf("cannot detect datastore. Specify it explicitly")
+		}
+
+		return d.NewDatastore(&i.Datastore[0]), nil
 	}
-	return &Datastore{
-		ds:     ds,
-		driver: d,
-	}, nil
 }
 
 func (ds *Datastore) Info(params ...string) (*mo.Datastore, error) {

--- a/driver/datastore_acc_test.go
+++ b/driver/datastore_acc_test.go
@@ -8,7 +8,7 @@ func TestDatastoreAcc(t *testing.T) {
 	initDriverAcceptanceTest(t)
 
 	d := newTestDriver(t)
-	ds, err := d.FindDatastore("datastore1")
+	ds, err := d.FindDatastore("datastore1", "")
 	if err != nil {
 		t.Fatalf("Cannot find the default datastore '%v': %v", "datastore1", err)
 	}

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -96,7 +96,7 @@ func (d *Driver) CreateVM(config *CreateConfig) (*VirtualMachine, error) {
 		host = h.host
 	}
 
-	datastore, err := d.FindDatastore(config.Datastore)
+	datastore, err := d.FindDatastore(config.Datastore, config.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (template *VirtualMachine) Clone(config *CloneConfig) (*VirtualMachine, err
 	poolRef := pool.pool.Reference()
 	relocateSpec.Pool = &poolRef
 
-	datastore, err := template.driver.FindDatastore(config.Datastore)
+	datastore, err := template.driver.FindDatastore(config.Datastore, config.Host)
 	if err != nil {
 		return nil, err
 	}

--- a/driver/vm_clone_acc_test.go
+++ b/driver/vm_clone_acc_test.go
@@ -29,7 +29,6 @@ func TestVMAcc_clone(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.config.Host = TestHostName
-			tc.config.Datastore = "datastore1"
 			tc.config.Name = newVMName()
 
 			templateName := "alpine"

--- a/driver/vm_create_acc_test.go
+++ b/driver/vm_create_acc_test.go
@@ -19,7 +19,6 @@ func TestVMAcc_create(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tc.config.Host = TestHostName
-			tc.config.Datastore = "datastore1"
 			tc.config.Name = newVMName()
 
 			d := newTestDriver(t)

--- a/examples/driver/main.go
+++ b/examples/driver/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"fmt"
+)
+
+func main() {
+	d, err := driver.NewDriver(&driver.ConnectConfig{
+		VCenterServer:      "vcenter.vsphere65.test",
+		Username:           "root",
+		Password:           "jetbrains",
+		InsecureConnection: true,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	ds, err := d.FindDatastore("", "esxi-1.vsphere65.test")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(ds.Name())
+}

--- a/iso/builder.go
+++ b/iso/builder.go
@@ -49,6 +49,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&StepAddFloppy{
 			Config:    &b.config.FloppyConfig,
 			Datastore: b.config.Datastore,
+			Host: b.config.Host,
 		},
 		&StepConfigParams{
 			Config:    &b.config.ConfigParamsConfig,

--- a/iso/builder_acc_test.go
+++ b/iso/builder_acc_test.go
@@ -27,7 +27,6 @@ func defaultConfig() map[string]interface{} {
 		"insecure_connection": true,
 
 		"host": "esxi-1.vsphere65.test",
-		"datastore": "datastore1",
 
 		"ssh_username": "root",
 		"ssh_password": "jetbrains",

--- a/iso/step_add_floppy.go
+++ b/iso/step_add_floppy.go
@@ -29,6 +29,7 @@ func (c *FloppyConfig) Prepare() []error {
 type StepAddFloppy struct {
 	Config    *FloppyConfig
 	Datastore string
+	Host string
 
 	uploadedFloppyPath string
 }
@@ -51,7 +52,7 @@ func (s *StepAddFloppy) runImpl(state multistep.StateBag) error {
 	if tmpFloppy != nil {
 		ui.Say("Uploading created floppy image")
 
-		ds, err := d.FindDatastore(s.Datastore)
+		ds, err := d.FindDatastore(s.Datastore, s.Host)
 		if err != nil {
 			return err
 		}
@@ -102,7 +103,7 @@ func (s *StepAddFloppy) Cleanup(state multistep.StateBag) {
 	}
 
 	if s.uploadedFloppyPath != "" {
-		ds, err := d.FindDatastore(s.Datastore)
+		ds, err := d.FindDatastore(s.Datastore, s.Host)
 		if err != nil {
 			ui.Error(err.Error())
 			return


### PR DESCRIPTION
`datastore` is optional only if the whole datacenter has a single datastore.

Now a datastore is automatically resolved from a target `host`.

If a host has multiple datastores, the plugin fails with 
```
Build 'vsphere-iso' errored: error creating vm: Host has multiple datastores. Specify it explicitly
```