### PR TITLE
Add new config options for setting CPU and Memory Hot Add

### DIFF
--- a/clone/builder_acc_test.go
+++ b/clone/builder_acc_test.go
@@ -327,8 +327,8 @@ func hardwareConfig() string {
 	config["CPU_limit"] = 1500
 	config["RAM"] = 2048
 	config["RAM_reservation"] = 1024
-	config["cpu_hot_add_enable"] = true
-	config["memory_hot_add_enable"] = true
+	config["CPU_hot_plug"] = true
+	config["RAM_hot_plug"] = true
 
 	return commonT.RenderConfig(config)
 }

--- a/clone/builder_acc_test.go
+++ b/clone/builder_acc_test.go
@@ -327,6 +327,8 @@ func hardwareConfig() string {
 	config["CPU_limit"] = 1500
 	config["RAM"] = 2048
 	config["RAM_reservation"] = 1024
+	config["cpu_hot_add_enable"] = true
+	config["memory_hot_add_enable"] = true
 
 	return commonT.RenderConfig(config)
 }
@@ -364,6 +366,16 @@ func checkHardware(t *testing.T) builderT.TestCheckFunc {
 		ramReservation := vmInfo.Config.MemoryAllocation.GetResourceAllocationInfo().Reservation
 		if ramReservation != 1024 {
 			t.Errorf("VM should have RAM reservation for 1024 MB, got %v", ramReservation)
+		}
+
+		cpuHotAdd := vmInfo.Config.CpuHotAddEnabled
+		if !*cpuHotAdd {
+			t.Errorf("VM should have CPU hot add enabled, got %v", cpuHotAdd)
+		}
+
+		memoryHotAdd := vmInfo.Config.MemoryHotAddEnabled
+		if !*memoryHotAdd {
+			t.Errorf("VM should have Memory hot add enabled, got %v", memoryHotAdd)
 		}
 
 		return nil

--- a/clone/step_hardware.go
+++ b/clone/step_hardware.go
@@ -19,14 +19,16 @@ func (s *StepConfigureHardware) Run(state multistep.StateBag) multistep.StepActi
 		ui.Say("Customizing hardware parameters...")
 
 		err := vm.Configure(&driver.HardwareConfig{
-			CPUs:           s.config.CPUs,
-			CPUReservation: s.config.CPUReservation,
-			CPULimit:       s.config.CPULimit,
-			RAM:            s.config.RAM,
-			RAMReservation: s.config.RAMReservation,
-			RAMReserveAll:  s.config.RAMReserveAll,
-			DiskSize:       s.config.DiskSize,
-			NestedHV:       s.config.NestedHV,
+			CPUs:                s.config.CPUs,
+			CPUReservation:      s.config.CPUReservation,
+			CPULimit:            s.config.CPULimit,
+			RAM:                 s.config.RAM,
+			RAMReservation:      s.config.RAMReservation,
+			RAMReserveAll:       s.config.RAMReserveAll,
+			DiskSize:            s.config.DiskSize,
+			NestedHV:            s.config.NestedHV,
+			CpuHotAddEnabled:    s.config.CpuHotAddEnabled,
+			MemoryHotAddEnabled: s.config.MemoryHotAddEnabled,
 		})
 		if err != nil {
 			state.Put("error", err)

--- a/common/hardware_config.go
+++ b/common/hardware_config.go
@@ -14,8 +14,8 @@ type HardwareConfig struct {
 	RAMReserveAll       bool  `mapstructure:"RAM_reserve_all"`
 	DiskSize            int64 `mapstructure:"disk_size"`
 	NestedHV            bool  `mapstructure:"NestedHV"`
-	CpuHotAddEnabled    bool  `mapstructure:"cpu_hot_add_enable"`
-	MemoryHotAddEnabled bool  `mapstructure:"memory_hot_add_enable"`
+	CpuHotAddEnabled    bool  `mapstructure:"CPU_hot_plug"`
+	MemoryHotAddEnabled bool  `mapstructure:"RAM_hot_plug"`
 }
 
 func (c *HardwareConfig) Prepare() []error {

--- a/common/hardware_config.go
+++ b/common/hardware_config.go
@@ -6,14 +6,16 @@ import (
 )
 
 type HardwareConfig struct {
-	CPUs           int32 `mapstructure:"CPUs"`
-	CPUReservation int64 `mapstructure:"CPU_reservation"`
-	CPULimit       int64 `mapstructure:"CPU_limit"`
-	RAM            int64 `mapstructure:"RAM"`
-	RAMReservation int64 `mapstructure:"RAM_reservation"`
-	RAMReserveAll  bool  `mapstructure:"RAM_reserve_all"`
-	DiskSize       int64 `mapstructure:"disk_size"`
-	NestedHV       bool  `mapstructure:"NestedHV"`
+	CPUs                int32 `mapstructure:"CPUs"`
+	CPUReservation      int64 `mapstructure:"CPU_reservation"`
+	CPULimit            int64 `mapstructure:"CPU_limit"`
+	RAM                 int64 `mapstructure:"RAM"`
+	RAMReservation      int64 `mapstructure:"RAM_reservation"`
+	RAMReserveAll       bool  `mapstructure:"RAM_reserve_all"`
+	DiskSize            int64 `mapstructure:"disk_size"`
+	NestedHV            bool  `mapstructure:"NestedHV"`
+	CpuHotAddEnabled    bool  `mapstructure:"cpu_hot_add_enable"`
+	MemoryHotAddEnabled bool  `mapstructure:"memory_hot_add_enable"`
 }
 
 func (c *HardwareConfig) Prepare() []error {
@@ -28,12 +30,14 @@ func (c *HardwareConfig) Prepare() []error {
 
 func (c *HardwareConfig) ToDriverHardwareConfig() driver.HardwareConfig {
 	return driver.HardwareConfig{
-		CPUs:           c.CPUs,
-		CPUReservation: c.CPUReservation,
-		CPULimit:       c.CPULimit,
-		RAM:            c.RAM,
-		RAMReservation: c.RAMReservation,
-		RAMReserveAll:  c.RAMReserveAll,
-		DiskSize:       c.DiskSize,
+		CPUs:                c.CPUs,
+		CPUReservation:      c.CPUReservation,
+		CPULimit:            c.CPULimit,
+		RAM:                 c.RAM,
+		RAMReservation:      c.RAMReservation,
+		RAMReserveAll:       c.RAMReserveAll,
+		DiskSize:            c.DiskSize,
+		CpuHotAddEnabled:    c.CpuHotAddEnabled,
+		MemoryHotAddEnabled: c.MemoryHotAddEnabled,
 	}
 }

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -26,14 +26,16 @@ type CloneConfig struct {
 }
 
 type HardwareConfig struct {
-	CPUs           int32
-	CPUReservation int64
-	CPULimit       int64
-	RAM            int64
-	RAMReservation int64
-	RAMReserveAll  bool
-	DiskSize       int64
-	NestedHV       bool
+	CPUs                int32
+	CPUReservation      int64
+	CPULimit            int64
+	RAM                 int64
+	RAMReservation      int64
+	RAMReserveAll       bool
+	DiskSize            int64
+	NestedHV            bool
+	CpuHotAddEnabled    bool
+	MemoryHotAddEnabled bool
 }
 
 type CreateConfig struct {
@@ -388,6 +390,9 @@ func (config HardwareConfig) toConfigSpec() types.VirtualMachineConfigSpec {
 
 	confSpec.MemoryReservationLockedToMax = &config.RAMReserveAll
 	confSpec.NestedHVEnabled = &config.NestedHV
+
+	confSpec.CpuHotAddEnabled = &config.CpuHotAddEnabled
+	confSpec.MemoryHotAddEnabled = &config.MemoryHotAddEnabled
 
 	return confSpec
 }

--- a/driver/vm_clone_acc_test.go
+++ b/driver/vm_clone_acc_test.go
@@ -115,11 +115,13 @@ func cloneDefaultCheck(t *testing.T, vm *VirtualMachine, config *CloneConfig) {
 func configureCheck(t *testing.T, vm *VirtualMachine, _ *CloneConfig) {
 	log.Printf("[DEBUG] Configuring the vm")
 	hwConfig := &HardwareConfig{
-		CPUs:           2,
-		CPUReservation: 1000,
-		CPULimit:       1500,
-		RAM:            2048,
-		RAMReservation: 1024,
+		CPUs:                2,
+		CPUReservation:      1000,
+		CPULimit:            1500,
+		RAM:                 2048,
+		RAMReservation:      1024,
+		MemoryHotAddEnabled: true,
+		CpuHotAddEnabled:    true,
 	}
 	vm.Configure(hwConfig)
 
@@ -152,6 +154,16 @@ func configureCheck(t *testing.T, vm *VirtualMachine, _ *CloneConfig) {
 	ramReservation := vmInfo.Config.MemoryAllocation.GetResourceAllocationInfo().Reservation
 	if ramReservation != hwConfig.RAMReservation {
 		t.Errorf("VM should have RAM reservation for %v MB, got %v", hwConfig.RAMReservation, ramReservation)
+	}
+
+	cpuHotAdd := vmInfo.Config.CpuHotAddEnabled
+	if *cpuHotAdd != hwConfig.CpuHotAddEnabled {
+		t.Errorf("VM should have CPU hot add set to %v, got %v", hwConfig.CpuHotAddEnabled, cpuHotAdd)
+	}
+
+	memoryHotAdd := vmInfo.Config.MemoryHotAddEnabled
+	if *memoryHotAdd != hwConfig.MemoryHotAddEnabled {
+		t.Errorf("VM should have Memroy hot add set to %v, got %v", hwConfig.MemoryHotAddEnabled, memoryHotAdd)
 	}
 }
 


### PR DESCRIPTION
Both the vsphere-iso and vsphere-clone builders get new config
options cpu_hot_add_enable and memory_hot_add_enable. These
new config options allow enabling and disabling the CPU and
Memory hot add features on virtual machines.