### PR TITLE
Fix cdrom and floppy drive unmounting issue when creating templates

### DIFF
--- a/iso/step_add_cdrom.go
+++ b/iso/step_add_cdrom.go
@@ -1,11 +1,11 @@
 package iso
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"github.com/mitchellh/multistep"
-	"fmt"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 type CDRomConfig struct {
@@ -40,16 +40,4 @@ func (s *StepAddCDRom) Run(state multistep.StateBag) multistep.StepAction {
 	return multistep.ActionContinue
 }
 
-func (s *StepAddCDRom) Cleanup(state multistep.StateBag) {
-	ui := state.Get("ui").(packer.Ui)
-	vm := state.Get("vm").(*driver.VirtualMachine)
-
-	devices, err := vm.Devices()
-	if err != nil {
-		ui.Error(fmt.Sprintf("error removing cdroms: %v", err))
-	}
-	cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
-	if err = vm.RemoveDevice(false, cdroms...); err != nil {
-		ui.Error(fmt.Sprintf("error removing cdroms: %v", err))
-	}
-}
+func (s *StepAddCDRom) Cleanup(state multistep.StateBag) {}

--- a/iso/step_add_floppy.go
+++ b/iso/step_add_floppy.go
@@ -1,11 +1,11 @@
 package iso
 
 import (
-	"github.com/mitchellh/multistep"
+	"fmt"
+
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"fmt"
-	"github.com/vmware/govmomi/vim25/types"
+	"github.com/mitchellh/multistep"
 )
 
 type FloppyConfig struct {
@@ -29,7 +29,7 @@ func (c *FloppyConfig) Prepare() []error {
 type StepAddFloppy struct {
 	Config    *FloppyConfig
 	Datastore string
-	Host string
+	Host      string
 
 	uploadedFloppyPath string
 }
@@ -88,29 +88,4 @@ func (s *StepAddFloppy) runImpl(state multistep.StateBag) error {
 	return nil
 }
 
-func (s *StepAddFloppy) Cleanup(state multistep.StateBag) {
-	ui := state.Get("ui").(packer.Ui)
-	vm := state.Get("vm").(*driver.VirtualMachine)
-	d := state.Get("driver").(*driver.Driver)
-
-	devices, err := vm.Devices()
-	if err != nil {
-		ui.Error(fmt.Sprintf("error removing floppy: %v", err))
-	}
-	cdroms := devices.SelectByType((*types.VirtualFloppy)(nil))
-	if err = vm.RemoveDevice(false, cdroms...); err != nil {
-		ui.Error(fmt.Sprintf("error removing floppy: %v", err))
-	}
-
-	if s.uploadedFloppyPath != "" {
-		ds, err := d.FindDatastore(s.Datastore, s.Host)
-		if err != nil {
-			ui.Error(err.Error())
-			return
-		}
-		if err := ds.Delete(s.uploadedFloppyPath); err != nil {
-			ui.Error(fmt.Sprintf("Error deleting floppy image '%v': %v", s.uploadedFloppyPath, err.Error()))
-			return
-		}
-	}
-}
+func (s *StepAddFloppy) Cleanup(state multistep.StateBag) {}

--- a/iso/step_remove_cdrom.go
+++ b/iso/step_remove_cdrom.go
@@ -1,0 +1,32 @@
+package iso
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/packer"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"github.com/mitchellh/multistep"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type StepRemoveCDRom struct{}
+
+func (s *StepRemoveCDRom) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	vm := state.Get("vm").(*driver.VirtualMachine)
+
+	devices, err := vm.Devices()
+	if err != nil {
+		ui.Error(fmt.Sprintf("error removing cdroms: %v", err))
+		return multistep.ActionHalt
+	}
+	cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
+	if err = vm.RemoveDevice(false, cdroms...); err != nil {
+		ui.Error(fmt.Sprintf("error removing cdroms: %v", err))
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepRemoveCDRom) Cleanup(state multistep.StateBag) {}

--- a/iso/step_remove_floppy.go
+++ b/iso/step_remove_floppy.go
@@ -1,0 +1,49 @@
+package iso
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/packer/packer"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"github.com/mitchellh/multistep"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type StepRemoveFloppy struct {
+	Datastore          string
+	Host               string
+	UploadedFloppyPath string
+}
+
+func (s *StepRemoveFloppy) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	vm := state.Get("vm").(*driver.VirtualMachine)
+	d := state.Get("driver").(*driver.Driver)
+
+	devices, err := vm.Devices()
+	if err != nil {
+		ui.Error(fmt.Sprintf("error removing floppy: %v", err))
+		return multistep.ActionHalt
+	}
+	cdroms := devices.SelectByType((*types.VirtualFloppy)(nil))
+	if err = vm.RemoveDevice(false, cdroms...); err != nil {
+		ui.Error(fmt.Sprintf("error removing floppy: %v", err))
+		return multistep.ActionHalt
+	}
+
+	if s.UploadedFloppyPath != "" {
+		ds, err := d.FindDatastore(s.Datastore, s.Host)
+		if err != nil {
+			ui.Error(err.Error())
+			return multistep.ActionHalt
+		}
+		if err := ds.Delete(s.UploadedFloppyPath); err != nil {
+			ui.Error(fmt.Sprintf("Error deleting floppy image '%v': %v", s.UploadedFloppyPath, err.Error()))
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepRemoveFloppy) Cleanup(state multistep.StateBag) {}


### PR DESCRIPTION
Sorry for the delay, I've been busy these days.

This fixes #59 

I'm not sure if there is a better way in golang to handle `uploadedFloppyPath` value.