### PR TITLE
Ensure CDRom and Floppy would be removed before converting into template

### DIFF
--- a/iso/builder.go
+++ b/iso/builder.go
@@ -78,6 +78,14 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 
 	steps = append(steps,
+		&StepRemoveCDRom{
+			Config: &b.config.CDRomConfig,
+		},
+		&StepRemoveFloppy{
+			Config:    &b.config.FloppyConfig,
+			Datastore: b.config.Datastore,
+			Host: b.config.Host,
+		},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
 		},

--- a/iso/step_add_cdrom.go
+++ b/iso/step_add_cdrom.go
@@ -5,7 +5,6 @@ import (
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"github.com/mitchellh/multistep"
 	"fmt"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 type CDRomConfig struct {
@@ -41,15 +40,4 @@ func (s *StepAddCDRom) Run(state multistep.StateBag) multistep.StepAction {
 }
 
 func (s *StepAddCDRom) Cleanup(state multistep.StateBag) {
-	ui := state.Get("ui").(packer.Ui)
-	vm := state.Get("vm").(*driver.VirtualMachine)
-
-	devices, err := vm.Devices()
-	if err != nil {
-		ui.Error(fmt.Sprintf("error removing cdroms: %v", err))
-	}
-	cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
-	if err = vm.RemoveDevice(false, cdroms...); err != nil {
-		ui.Error(fmt.Sprintf("error removing cdroms: %v", err))
-	}
 }

--- a/iso/step_add_floppy.go
+++ b/iso/step_add_floppy.go
@@ -5,7 +5,6 @@ import (
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"fmt"
-	"github.com/vmware/govmomi/vim25/types"
 )
 
 type FloppyConfig struct {
@@ -29,7 +28,7 @@ func (c *FloppyConfig) Prepare() []error {
 type StepAddFloppy struct {
 	Config    *FloppyConfig
 	Datastore string
-	Host string
+	Host      string
 
 	uploadedFloppyPath string
 }
@@ -89,28 +88,4 @@ func (s *StepAddFloppy) runImpl(state multistep.StateBag) error {
 }
 
 func (s *StepAddFloppy) Cleanup(state multistep.StateBag) {
-	ui := state.Get("ui").(packer.Ui)
-	vm := state.Get("vm").(*driver.VirtualMachine)
-	d := state.Get("driver").(*driver.Driver)
-
-	devices, err := vm.Devices()
-	if err != nil {
-		ui.Error(fmt.Sprintf("error removing floppy: %v", err))
-	}
-	cdroms := devices.SelectByType((*types.VirtualFloppy)(nil))
-	if err = vm.RemoveDevice(false, cdroms...); err != nil {
-		ui.Error(fmt.Sprintf("error removing floppy: %v", err))
-	}
-
-	if s.uploadedFloppyPath != "" {
-		ds, err := d.FindDatastore(s.Datastore, s.Host)
-		if err != nil {
-			ui.Error(err.Error())
-			return
-		}
-		if err := ds.Delete(s.uploadedFloppyPath); err != nil {
-			ui.Error(fmt.Sprintf("Error deleting floppy image '%v': %v", s.uploadedFloppyPath, err.Error()))
-			return
-		}
-	}
 }

--- a/iso/step_remove_cdrom.go
+++ b/iso/step_remove_cdrom.go
@@ -1,0 +1,36 @@
+package iso
+
+import (
+	"github.com/hashicorp/packer/packer"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"github.com/mitchellh/multistep"
+	"fmt"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type StepRemoveCDRom struct {
+	Config *CDRomConfig
+}
+
+func (s *StepRemoveCDRom) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	vm := state.Get("vm").(*driver.VirtualMachine)
+
+	ui.Say("Removing CDRoms...")
+	devices, err := vm.Devices()
+	if err != nil {
+		state.Put("error", fmt.Errorf("error removing cdrom: error listing devices: %v", err))
+		return multistep.ActionHalt
+	}
+	cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
+	if err = vm.RemoveDevice(false, cdroms...); err != nil {
+		state.Put("error", fmt.Errorf("error removing cdrom: %v", err))
+
+		return multistep.ActionHalt
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepRemoveCDRom) Cleanup(state multistep.StateBag) {
+}

--- a/iso/step_remove_floppy.go
+++ b/iso/step_remove_floppy.go
@@ -1,0 +1,53 @@
+package iso
+
+import (
+	"github.com/mitchellh/multistep"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"fmt"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type StepRemoveFloppy struct {
+	Config    *FloppyConfig
+	Datastore string
+	Host      string
+
+	uploadedFloppyPath string
+}
+
+func (s *StepRemoveFloppy) Run(state multistep.StateBag) multistep.StepAction {
+	err := s.runImpl(state)
+	if err != nil {
+		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+	return multistep.ActionContinue
+}
+
+func (s *StepRemoveFloppy) runImpl(state multistep.StateBag) error {
+	vm := state.Get("vm").(*driver.VirtualMachine)
+	d := state.Get("driver").(*driver.Driver)
+
+	devices, err := vm.Devices()
+	if err != nil {
+		return fmt.Errorf("error removing floppy: %v", err)
+	}
+	cdroms := devices.SelectByType((*types.VirtualFloppy)(nil))
+	if err = vm.RemoveDevice(false, cdroms...); err != nil {
+		return fmt.Errorf("error removing floppy: %v", err)
+	}
+
+	if s.uploadedFloppyPath != "" {
+		ds, err := d.FindDatastore(s.Datastore, s.Host)
+		if err != nil {
+			return fmt.Errorf("error removing floppy: %v", err)
+		}
+		if err := ds.Delete(s.uploadedFloppyPath); err != nil {
+			return fmt.Errorf("error deleting floppy image '%v': %v", s.uploadedFloppyPath, err.Error())
+		}
+	}
+	return nil
+}
+
+func (s *StepRemoveFloppy) Cleanup(state multistep.StateBag) {
+}


### PR DESCRIPTION
Extract `StepAddX.Cleanup` into separate `StepRemoveX` steps to ensure they're runned before VM converted into template.
Resolves problems like:
```text
[18:10:52]==> vsphere-iso: Shut down VM...
[18:10:58]==> vsphere-iso: VM stopped
[18:10:58]==> vsphere-iso: Creating snapshot...
[18:11:02]==> vsphere-iso: Convert VM into template...
[18:11:02]==> vsphere-iso: error removing floppy: The operation is not supported on the object.
[18:11:03]==> vsphere-iso: error removing cdroms: The operation is not supported on the object.
```