### PR TITLE
Fix build cancellation

### DIFF
--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -34,7 +34,7 @@ type StepCloneVM struct {
 	Location *common.LocationConfig
 }
 
-func (s *StepCloneVM) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	d := state.Get("driver").(*driver.Driver)
 
@@ -46,7 +46,7 @@ func (s *StepCloneVM) Run(_ context.Context, state multistep.StateBag) multistep
 		return multistep.ActionHalt
 	}
 
-	vm, err := template.Clone(&driver.CloneConfig{
+	vm, err := template.Clone(ctx, &driver.CloneConfig{
 		Name:         s.Location.VMName,
 		Folder:       s.Location.Folder,
 		Cluster:      s.Location.Cluster,
@@ -57,6 +57,9 @@ func (s *StepCloneVM) Run(_ context.Context, state multistep.StateBag) multistep
 	})
 	if err != nil {
 		state.Put("error", err)
+		return multistep.ActionHalt
+	}
+	if vm == nil {
 		return multistep.ActionHalt
 	}
 	state.Put("vm", vm)

--- a/common/step_connect.go
+++ b/common/step_connect.go
@@ -35,8 +35,8 @@ type StepConnect struct {
 	Config *ConnectConfig
 }
 
-func (s *StepConnect) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
-	d, err := driver.NewDriver(ctx, &driver.ConnectConfig{
+func (s *StepConnect) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	d, err := driver.NewDriver(&driver.ConnectConfig{
 		VCenterServer:      s.Config.VCenterServer,
 		Username:           s.Config.Username,
 		Password:           s.Config.Password,

--- a/common/step_shutdown.go
+++ b/common/step_shutdown.go
@@ -39,7 +39,7 @@ type StepShutdown struct {
 	Config *ShutdownConfig
 }
 
-func (s *StepShutdown) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+func (s *StepShutdown) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	ui := state.Get("ui").(packer.Ui)
 	comm := state.Get("communicator").(packer.Communicator)
 	vm := state.Get("vm").(*driver.VirtualMachine)
@@ -70,7 +70,7 @@ func (s *StepShutdown) Run(_ context.Context, state multistep.StateBag) multiste
 	}
 
 	log.Printf("Waiting max %s for shutdown to complete", s.Config.Timeout)
-	err := vm.WaitForShutdown(s.Config.Timeout)
+	err := vm.WaitForShutdown(ctx, s.Config.Timeout)
 	if err != nil {
 		state.Put("error", err)
 		return multistep.ActionHalt

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -28,7 +28,8 @@ type ConnectConfig struct {
 	Datacenter         string
 }
 
-func NewDriver(ctx context.Context, config *ConnectConfig) (*Driver, error) {
+func NewDriver(config *ConnectConfig) (*Driver, error) {
+	ctx := context.TODO()
 
 	vcenter_url, err := url.Parse(fmt.Sprintf("https://%v/sdk", config.VCenterServer))
 	if err != nil {

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -335,8 +335,8 @@ func (vm *VirtualMachine) PowerOn() error {
 	return err
 }
 
-func (vm *VirtualMachine) WaitForIP() (string, error) {
-	return vm.vm.WaitForIP(vm.driver.ctx)
+func (vm *VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
+	return vm.vm.WaitForIP(ctx)
 }
 
 func (vm *VirtualMachine) PowerOff() error {

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -362,7 +362,7 @@ func (vm *VirtualMachine) StartShutdown() error {
 	return err
 }
 
-func (vm *VirtualMachine) WaitForShutdown(timeout time.Duration) error {
+func (vm *VirtualMachine) WaitForShutdown(ctx context.Context, timeout time.Duration) error {
 	shutdownTimer := time.After(timeout)
 	for {
 		powerState, err := vm.vm.PowerState(vm.driver.ctx)
@@ -377,6 +377,8 @@ func (vm *VirtualMachine) WaitForShutdown(timeout time.Duration) error {
 		case <-shutdownTimer:
 			err := errors.New("Timeout while waiting for machine to shut down.")
 			return err
+		case <-ctx.Done():
+			return nil
 		default:
 			time.Sleep(1 * time.Second)
 		}

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -8,6 +8,7 @@ import (
 	"github.com/vmware/govmomi/vim25/types"
 	"time"
 	"strings"
+	"context"
 )
 
 type VirtualMachine struct {
@@ -178,7 +179,7 @@ func (vm *VirtualMachine) Devices() (object.VirtualDeviceList, error) {
 	return vmInfo.Config.Hardware.Device, nil
 }
 
-func (template *VirtualMachine) Clone(config *CloneConfig) (*VirtualMachine, error) {
+func (template *VirtualMachine) Clone(ctx context.Context, config *CloneConfig) (*VirtualMachine, error) {
 	folder, err := template.driver.FindFolder(config.Folder)
 	if err != nil {
 		return nil, err
@@ -223,8 +224,13 @@ func (template *VirtualMachine) Clone(config *CloneConfig) (*VirtualMachine, err
 		return nil, err
 	}
 
-	info, err := task.WaitForResult(template.driver.ctx, nil)
+	info, err := task.WaitForResult(ctx, nil)
 	if err != nil {
+		if ctx.Err() == context.Canceled {
+			err = task.Cancel(context.TODO())
+			return nil, err
+		}
+
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes #100.

Packer 1.2 introduced context propagation. #84 saved a context of the first step in a driver object. Later steps try to reuse it, but fail because the context is already canceled. Each step should have its own context.

Now the context is explicitly passed to the driver methods, but only for 3 real use cases:
1) VM cloning
2) Waiting for IP address 
3) Waiting for VM shutdown

Other actions do not take much time, so we can ignore cancellation requests.