### PR TITLE
Support for more than one disk #68

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `RAM_reserve_all`(boolean) - Reserve all available RAM. Defaults to `false`. Cannot be used together with `RAM_reservation`.
 * `RAM_hot_plug`(boolean) - Enable RAM hot plug setting for virtual machine. Defaults to `false`.
 * `video_ram`(number) - Amount of video memory in MB.
-* `disk_size`(number) - The size of the disk in MB.
-* `network`(string) - Set network VM will be connected to.
+* `disk_size`(number) - The size of the disk in MB. (deprecated for `vsphere-iso`)
+* `network`(string) - Set network VM will be connected to. (deprecated for `vsphere-iso`)
 * `NestedHV`(boolean) - Enable nested hardware virtualization for VM. Defaults to `false`.
 * `configuration_parameters`(map) - Custom parameters.
 * `boot_order`(string) - Priority of boot devices. Defaults to `disk,cdrom`
@@ -83,12 +83,31 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `vm_version`(number) - Set VM hardware version. Defaults to the most current VM hardware version supported by vCenter. See [VMWare article 1003746](https://kb.vmware.com/s/article/1003746) for the full list of supported VM hardware versions.
 * `guest_os_type`(string) - Set VM OS type. Defaults to `otherGuest`. See [here](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.GuestOsDescriptor.GuestOsIdentifier.html) for a full list of possible values.
 * `disk_controller_type`(string) - Set VM disk controller type. Example `pvscsi`.
-* `disk_thin_provisioned`(boolean) - Enable VMDK thin provisioning for VM. Defaults to `false`.
+* `disk_thin_provisioned`(boolean) - Enable VMDK thin provisioning for VM. Defaults to `false`. (deprecated)
 * `network_card`(string) - Set VM network card type. Example `vmxnet3`.
 * `usb_controller`(boolean) - Create USB controller for virtual machine. Defaults to `false`.
 * `cdrom_type`(string) - Which controller to use. Example `sata`. Defaults to `ide`.
 * `firmware`(string) - Set the Firmware at machine creation. Example `efi`. Defaults to `bios`.
+* `networks`(array of strings) - List of networks the VM will be connected to. Supersedes `network`.
+* `disk_type`(string) - Type of disk to create. One of `thick_eager`, `thick_lazy` or `thin`. Defaults to `thick_lazy`. Can be overridden per disk in the `storage` array.
+* `storage`(array of disk definitions) - List of disks definitions. Supersedes `disk_size`.
+    * `disk_name`(string) - For human readability only (optional).
+    * `disk_size`(number) - The size of the disk in MB.
+    * `disk_type`(string) - The type of disk (optional, see `disk_type`).
 
+```
+"storage": [
+  {
+    "disk_name": "sda",
+    "disk_size": 8192,
+    "disk_type": "thin"
+  },
+  {
+    "disk_name": "sdb",
+    "disk_size": 16384,
+  }
+]
+```
 
 ### Boot (`vsphere-iso` only)
 

--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -15,9 +15,6 @@ type CloneConfig struct {
 	LinkedClone bool   `mapstructure:"linked_clone"`
 	Network     string `mapstructure:"network"`
 	Notes       string `mapstructure:"notes"`
-
-	Networks    []string `mapstructure:"networks"`
-	NetworkCard string   `mapstructure:"network_card"`
 }
 
 func (c *CloneConfig) Prepare() []error {
@@ -74,8 +71,6 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		LinkedClone:  s.Config.LinkedClone,
 		Network:      s.Config.Network,
 		Annotation:   s.Config.Notes,
-		Networks:     s.Config.Networks,
-		NetworkCard:  s.Config.NetworkCard,
 	})
 	if err != nil {
 		state.Put("error", err)

--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -15,6 +15,8 @@ type CloneConfig struct {
 	LinkedClone bool   `mapstructure:"linked_clone"`
 	Network     string `mapstructure:"network"`
 	Notes       string `mapstructure:"notes"`
+
+	Networks []string `mapstructure:"networks"`
 }
 
 func (c *CloneConfig) Prepare() []error {
@@ -71,6 +73,8 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		LinkedClone:  s.Config.LinkedClone,
 		Network:      s.Config.Network,
 		Annotation:   s.Config.Notes,
+		Networks:     s.Config.Networks,
+		NetworkCard:  s.Config.NetworkCard,
 	})
 	if err != nil {
 		state.Put("error", err)

--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -16,7 +16,8 @@ type CloneConfig struct {
 	Network     string `mapstructure:"network"`
 	Notes       string `mapstructure:"notes"`
 
-	Networks []string `mapstructure:"networks"`
+	Networks    []string `mapstructure:"networks"`
+	NetworkCard string   `mapstructure:"network_card"`
 }
 
 func (c *CloneConfig) Prepare() []error {

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -72,8 +72,8 @@ type DiskConfig struct {
 	DiskSize int64   `mapstructure:"disk_size"`
 	DiskType string  `mapstructure:"disk_type"`
 
-	diskEagerlyScrub    bool
-	diskThinProvisioned bool
+	DiskEagerlyScrub    bool
+	DiskThinProvisioned bool
 }
 
 func (d *Driver) NewVM(ref *types.ManagedObjectReference) *VirtualMachine {
@@ -541,32 +541,13 @@ func addDisks(_ *Driver, devices object.VirtualDeviceList, config *CreateConfig)
 	}
 
 	for _, dc := range config.Storage {
-		if dc.DiskType == "" && config.GlobalDiskType != "" {
-			dc.DiskType = config.GlobalDiskType
-		}
-
-		if dc.DiskType == "thin" {
-			dc.diskEagerlyScrub    = false
-			dc.diskThinProvisioned = true
-		} else if dc.DiskType == "thick_eager" {
-			dc.diskEagerlyScrub    = true
-			dc.diskThinProvisioned = false
-		} else if dc.DiskType == "thick_lazy" {
-			dc.diskEagerlyScrub    = false
-			dc.diskThinProvisioned = false
-		} else {
-			// default disk type: Thick provisioned lazy zeroed
-			dc.diskEagerlyScrub    = false
-			dc.diskThinProvisioned = false
-		}
-
 		disk := &types.VirtualDisk{
 			VirtualDevice: types.VirtualDevice{
 				Key: devices.NewKey(),
 				Backing: &types.VirtualDiskFlatVer2BackingInfo{
 					DiskMode:        string(types.VirtualDiskModePersistent),
-					EagerlyScrub:    types.NewBool(dc.diskEagerlyScrub),
-					ThinProvisioned: types.NewBool(dc.diskThinProvisioned),
+					EagerlyScrub:    types.NewBool(dc.DiskEagerlyScrub),
+					ThinProvisioned: types.NewBool(dc.DiskThinProvisioned),
 				},
 			},
 			CapacityInKB: dc.DiskSize * 1024,

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -72,8 +72,8 @@ type DiskConfig struct {
 	DiskSize int64   `mapstructure:"disk_size"`
 	DiskType string  `mapstructure:"disk_type"`
 
-	DiskEagerlyScrub    bool
-	DiskThinProvisioned bool
+	diskEagerlyScrub    bool
+	diskThinProvisioned bool
 }
 
 func (d *Driver) NewVM(ref *types.ManagedObjectReference) *VirtualMachine {
@@ -546,18 +546,18 @@ func addDisks(_ *Driver, devices object.VirtualDeviceList, config *CreateConfig)
 		}
 
 		if dc.DiskType == "thin" {
-			dc.DiskEagerlyScrub    = false
-			dc.DiskThinProvisioned = true
+			dc.diskEagerlyScrub    = false
+			dc.diskThinProvisioned = true
 		} else if dc.DiskType == "thick_eager" {
-			dc.DiskEagerlyScrub    = true
-			dc.DiskThinProvisioned = false
+			dc.diskEagerlyScrub    = true
+			dc.diskThinProvisioned = false
 		} else if dc.DiskType == "thick_lazy" {
-			dc.DiskEagerlyScrub    = false
-			dc.DiskThinProvisioned = false
+			dc.diskEagerlyScrub    = false
+			dc.diskThinProvisioned = false
 		} else {
 			// default disk type: Thick provisioned lazy zeroed
-			dc.DiskEagerlyScrub    = false
-			dc.DiskThinProvisioned = false
+			dc.diskEagerlyScrub    = false
+			dc.diskThinProvisioned = false
 		}
 
 		disk := &types.VirtualDisk{
@@ -565,8 +565,8 @@ func addDisks(_ *Driver, devices object.VirtualDeviceList, config *CreateConfig)
 				Key: devices.NewKey(),
 				Backing: &types.VirtualDiskFlatVer2BackingInfo{
 					DiskMode:        string(types.VirtualDiskModePersistent),
-					EagerlyScrub:    types.NewBool(dc.DiskEagerlyScrub),
-					ThinProvisioned: types.NewBool(dc.DiskThinProvisioned),
+					EagerlyScrub:    types.NewBool(dc.diskEagerlyScrub),
+					ThinProvisioned: types.NewBool(dc.diskThinProvisioned),
 				},
 			},
 			CapacityInKB: dc.DiskSize * 1024,

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -28,6 +28,7 @@ type CloneConfig struct {
 	Network      string
 	Annotation   string
 	Networks     []string
+	NetworkCard  string
 }
 
 type HardwareConfig struct {
@@ -612,49 +613,6 @@ func addNetwork(d *Driver, devices object.VirtualDeviceList, config *CreateConfi
 	}
 
 	return append(devices, device), nil
-}
-
-func addNetworks(d *Driver, devices object.VirtualDeviceList, config *CreateConfig) (object.VirtualDeviceList, error) {
-	var network object.NetworkReference
-	if len(config.Networks) == 0 {
-		h, err := d.FindHost(config.Host)
-		if err != nil {
-			return nil, err
-		}
-
-		i, err := h.Info("network")
-		if err != nil {
-			return nil, err
-		}
-
-		if len(i.Network) > 1 {
-			return nil, fmt.Errorf("Host has multiple networks. Specify it explicitly")
-		}
-
-		network = object.NewNetwork(d.client.Client, i.Network[0])
-	} else {
-		var err error
-		for _, networkName := range config.Networks {
-			network, err := d.finder.Network(d.ctx, networkName)
-			if err != nil {
-				return nil, err
-			}
-
-			backing, err := network.EthernetCardBackingInfo(d.ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			device, err := object.EthernetCardTypes().CreateEthernetCard(config.NetworkCard, backing)
-			if err != nil {
-				return nil, err
-			}
-
-			devices = append(devices, device)
-		}
-	}
-
-	return devices, nil
 }
 
 func (vm *VirtualMachine) AddCdrom(controllerType string, isoPath string) error {

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -39,6 +39,24 @@ func (c *CreateConfig) Prepare() []error {
 		errs = append(errs, fmt.Errorf("either 'disk_size' or 'storage' is required"))
 	}
 
+	for disk, dc := range c.Storage {
+		if dc.DiskType == "" && c.GlobalDiskType != "" {
+			dc.DiskType = c.GlobalDiskType
+		}
+
+		if dc.DiskType == "thin" {
+			c.Storage[disk].DiskEagerlyScrub = false
+			c.Storage[disk].DiskThinProvisioned = true
+		} else if dc.DiskType == "thick_eager" {
+			c.Storage[disk].DiskEagerlyScrub = true
+			c.Storage[disk].DiskThinProvisioned = false
+		} else {
+			// default: dc.DiskType == "thick_lazy"
+			c.Storage[disk].DiskEagerlyScrub = false
+			c.Storage[disk].DiskThinProvisioned = false
+		}
+	}
+
 	if c.GuestOSType == "" {
 		c.GuestOSType = "otherGuest"
 	}

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -32,9 +32,11 @@ type CreateConfig struct {
 func (c *CreateConfig) Prepare() []error {
 	var errs []error
 
-  // to do: accept parameter 'DiskSize' or 'Storage', but not both at the same time
-	if c.DiskSize == 0 {
-		errs = append(errs, fmt.Errorf("'disk_size' is required"))
+	// options 'DiskSize' and 'Storage' are but mutually exclusive, but one is required
+	if c.DiskSize != 0 && len(c.Storage) != 0 {
+		errs = append(errs, fmt.Errorf("'disk_size' and 'storage' are mutually exclusive"))
+	} else if c.DiskSize == 0 && len(c.Storage) == 0 {
+		errs = append(errs, fmt.Errorf("either 'disk_size' or 'storage' is required"))
 	}
 
 	if c.GuestOSType == "" {

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -23,11 +23,16 @@ type CreateConfig struct {
 	USBController bool   `mapstructure:"usb_controller"`
 
 	Notes string `mapstructure:"notes"`
+
+	GlobalDiskType string              `mapstructure:"disk_type"`
+	Networks       []string            `mapstructure:"networks"`
+	Storage        []driver.DiskConfig `mapstructure:"storage"`
 }
 
 func (c *CreateConfig) Prepare() []error {
 	var errs []error
 
+  // to do: accept parameter 'DiskSize' or 'Storage', but not both at the same time
 	if c.DiskSize == 0 {
 		errs = append(errs, fmt.Errorf("'disk_size' is required"))
 	}
@@ -84,6 +89,9 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 		Version:             s.Config.Version,
 		Firmware:            s.Config.Firmware,
 		Annotation:          s.Config.Notes,
+		GlobalDiskType:      s.Config.GlobalDiskType,
+		Networks:            s.Config.Networks,
+		Storage:             s.Config.Storage,
 	})
 	if err != nil {
 		state.Put("error", fmt.Errorf("error creating vm: %v", err))


### PR DESCRIPTION
fixes #68 

The following tasks have been completed:
- add multiple disk support to the iso builder
- translate the requested disk type (e.g. thin) to the required internal options for that choice
- provide the option to set the disk type globally (for all disks) and per disk (which overrides the global option)

The following tasks are still pending:
- add support for naming disks
- add multiple disk support to the clone builder
- update documentation (README.md)
- clean up commit history

The following changes were done for testing and should be reverted before merging:
- change from SATA to IDE controller for the cd-rom
- hash out all build options except for the iso builder on Linux

Also, code for an internal HTTP server was added (based on other plugins that already support it). When this is finished, it will be presented in a seperate pull request.
