### PR TITLE
#108 Support for local HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `winrm_username`(string) - Username in guest OS.
 * `winrm_password`(string) - Password to access guest OS.
 
+* `http_directory`(string) - Path to a directory to serve using an HTTP server.
+* `http_ip`       (string) - Specify IP address on which the HTTP server is started. If not provided the first non-loopback interface is used.
+
 * `shutdown_command`(string) - Specify a VM guest shutdown command. VMware guest tools are used by default.
 * `shutdown_timeout`(string) - Amount of time to wait for graceful VM shutdown. Examples 45s and 10m. Defaults to 5m(5 minutes). See the Go Lang [ParseDuration](https://golang.org/pkg/time/#ParseDuration) documentation for full details.
 

--- a/iso/builder.go
+++ b/iso/builder.go
@@ -62,6 +62,11 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 				Datastore: b.config.Datastore,
 				Host:      b.config.Host,
 			},
+			&packerCommon.StepHTTPServer{
+				HTTPDir:     b.config.HTTPDir,
+				HTTPPortMin: b.config.HTTPPortMin,
+				HTTPPortMax: b.config.HTTPPortMax,
+			},
 			&common.StepRun{
 				Config: &b.config.RunConfig,
 			},

--- a/iso/config.go
+++ b/iso/config.go
@@ -11,6 +11,7 @@ import (
 
 type Config struct {
 	packerCommon.PackerConfig `mapstructure:",squash"`
+    packerCommon.HTTPConfig   `mapstructure:",squash"`
 
 	common.ConnectConfig      `mapstructure:",squash"`
 	CreateConfig              `mapstructure:",squash"`
@@ -46,6 +47,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	errs = packer.MultiErrorAppend(errs, c.CreateConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.LocationConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
+    errs = packer.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
 
 	errs = packer.MultiErrorAppend(errs, c.RunConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare()...)

--- a/iso/config.go
+++ b/iso/config.go
@@ -3,15 +3,15 @@ package iso
 import (
 	packerCommon "github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
-	"github.com/hashicorp/packer/helper/config"
 )
 
 type Config struct {
 	packerCommon.PackerConfig `mapstructure:",squash"`
-    packerCommon.HTTPConfig   `mapstructure:",squash"`
+	packerCommon.HTTPConfig   `mapstructure:",squash"`
 
 	common.ConnectConfig      `mapstructure:",squash"`
 	CreateConfig              `mapstructure:",squash"`
@@ -47,7 +47,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	errs = packer.MultiErrorAppend(errs, c.CreateConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.LocationConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
-    errs = packer.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
+	errs = packer.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
 
 	errs = packer.MultiErrorAppend(errs, c.RunConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare()...)

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -35,6 +35,7 @@ func getHostIP() string {
 	for _, a := range addrs {
 		if ip, ok := a.(*net.IPNet); ok && !ip.IP.IsLoopback() {
 			ipaddr = ip.IP.String()
+			break
 		}
 	}
 	return ipaddr

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -3,6 +3,7 @@ package iso
 import (
 	"fmt"
 	"net"
+	"os"
 
 	packerCommon "github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/packer"
@@ -23,13 +24,19 @@ type CreateConfig struct {
 	Network       string `mapstructure:"network"`
 	NetworkCard   string `mapstructure:"network_card"`
 	USBController bool   `mapstructure:"usb_controller"`
+	HTTPIP        string `mapstructure:"http_ip"`
 }
 
-func getHostIP() string {
+func getHostIP(s string) string {
+	if net.ParseIP(s) != nil {
+		return s
+	}
+
 	var ipaddr string
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
-		return ""
+		fmt.Println(err)
+		os.Exit(2)
 	}
 
 	for _, a := range addrs {
@@ -66,8 +73,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 
 	ui.Say("Creating VM...")
 
-	hostIP := getHostIP()
-	packerCommon.SetHTTPIP(hostIP)
+	packerCommon.SetHTTPIP(getHostIP(s.Config.HTTPIP))
 
 	vm, err := d.CreateVM(&driver.CreateConfig{
 		DiskThinProvisioned: s.Config.DiskThinProvisioned,

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -1,16 +1,16 @@
 package iso
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 
 	packerCommon "github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
-	"context"
 )
 
 type CreateConfig struct {
@@ -71,10 +71,9 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	ui := state.Get("ui").(packer.Ui)
 	d := state.Get("driver").(*driver.Driver)
 
-	ui.Say("Creating VM...")
-
 	packerCommon.SetHTTPIP(getHostIP(s.Config.HTTPIP))
 
+	ui.Say("Creating VM...")
 	vm, err := d.CreateVM(&driver.CreateConfig{
 		DiskThinProvisioned: s.Config.DiskThinProvisioned,
 		DiskControllerType:  s.Config.DiskControllerType,


### PR DESCRIPTION
fix #108 

If the `http_directory` key is set in the Packer template an HTTP server is started, which is accessible by the created VM.
The IP address on which the HTTP server is started is determined as the first non-loopback interface IP address; if needed this can be overridden by setting the `http_ip` key in the Packer template.