### PR TITLE
Gofmt, remove network card, examples centos7, fix gopkg, fixing CPU_limit

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -92,14 +92,14 @@
     "template/interpolate",
     "version"
   ]
-  revision = "b4df69af04373ef28caef3601befcaec1f909216"
-  version = "v1.2.3"
+  revision = "d1cc5451e933f39986bdc1069e9d26e534cde548"
+  version = "v1.2.5"
 
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/yamux"
   packages = ["."]
-  revision = "2658be15c5f05e76244154714161f17e3e77de2e"
+  revision = "cc6d2ea263b2471faabce371255777a365bf8306"
 
 [[projects]]
   name = "github.com/kr/fs"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,10 +1,10 @@
 [[constraint]]
   name = "github.com/hashicorp/packer"
-  version = "~1.2"
+  version = "~1.2.0"
 
 [[constraint]]
   name = "github.com/vmware/govmomi"
-  version = "~0.17"
+  version = "~0.17.0"
 
 [[override]]
   name = "github.com/masterzen/azure-sdk-for-go"

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 
 ### Postprocessing
 
+* `remove_network_card`(boolean) - Remove all network cards before creating a snapshot/template if set to `true`. Defaults to `false`.
 * `create_snapshot`(boolean) - Create a snapshot when set to `true`, so the VM can be used as a base for linked clones. Defaults to `false`.
 * `convert_to_template`(boolean) - Convert VM to a template. Defaults to `false`.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ This a plugin for [HashiCorp Packer](https://www.packer.io/). It uses native vSp
 * Download binaries from the [releases page](https://github.com/jetbrains-infra/packer-builder-vsphere/releases).
 * [Install](https://www.packer.io/docs/extending/plugins.html#installing-plugins) the plugins, or simply put them into the same directory with JSON templates. On Linux and macOS run `chmod +x` on the files.
 
+##Build
+
+Use docker and docker-compose
+```
+docker-compose up
+```
+the binary will be in bin/ folder
+
+
 ## Examples
 
 See complete Ubuntu, Windows, and macOS templates in the [examples folder](https://github.com/jetbrains-infra/packer-builder-vsphere/tree/master/examples/).

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ export GOARCH=amd64
 mkdir -p bin
 rm -f bin/*
 
+gofmt -e -w .
+
 GOOS=darwin  go build -o bin/packer-builder-vsphere-iso.macos ./cmd/iso
 GOOS=linux   go build -o bin/packer-builder-vsphere-iso.linux ./cmd/iso
 GOOS=windows go build -o bin/packer-builder-vsphere-iso.exe   ./cmd/iso

--- a/clone/builder.go
+++ b/clone/builder.go
@@ -2,11 +2,11 @@ package clone
 
 import (
 	packerCommon "github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
-	"github.com/hashicorp/packer/helper/communicator"
 )
 
 type Builder struct {
@@ -67,6 +67,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 
 	steps = append(steps,
+		&common.StepRemoveNetworkCard{
+			RemoveNetworkCard: b.config.RemoveNetworkCard,
+		},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
 		},

--- a/clone/builder_acc_test.go
+++ b/clone/builder_acc_test.go
@@ -5,8 +5,8 @@ import (
 	commonT "github.com/jetbrains-infra/packer-builder-vsphere/common/testing"
 
 	"github.com/hashicorp/packer/packer"
-	"testing"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
+	"testing"
 )
 
 func TestCloneBuilderAcc_default(t *testing.T) {

--- a/clone/config.go
+++ b/clone/config.go
@@ -3,10 +3,10 @@ package clone
 import (
 	packerCommon "github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
-	"github.com/hashicorp/packer/helper/config"
 )
 
 type Config struct {
@@ -18,12 +18,13 @@ type Config struct {
 	common.HardwareConfig     `mapstructure:",squash"`
 	common.ConfigParamsConfig `mapstructure:",squash"`
 
-	common.RunConfig         `mapstructure:",squash"`
-	Comm communicator.Config `mapstructure:",squash"`
-	common.ShutdownConfig    `mapstructure:",squash"`
+	common.RunConfig      `mapstructure:",squash"`
+	Comm                  communicator.Config `mapstructure:",squash"`
+	common.ShutdownConfig `mapstructure:",squash"`
 
 	CreateSnapshot    bool `mapstructure:"create_snapshot"`
 	ConvertToTemplate bool `mapstructure:"convert_to_template"`
+	RemoveNetworkCard bool `mapstructure:"remove_network_card"`
 
 	ctx interpolate.Context
 }

--- a/clone/config_test.go
+++ b/clone/config_test.go
@@ -25,7 +25,7 @@ func TestCloneConfig_Timeout(t *testing.T) {
 	raw["shutdown_timeout"] = "3m"
 	conf, warns, err := NewConfig(raw)
 	testConfigOk(t, warns, err)
-	if conf.ShutdownConfig.Timeout != 3 * time.Minute {
+	if conf.ShutdownConfig.Timeout != 3*time.Minute {
 		t.Fatalf("shutdown_timeout sould be equal 3 minutes, got %v", conf.ShutdownConfig.Timeout)
 	}
 }
@@ -41,13 +41,13 @@ func TestCloneConfig_RAMReservation(t *testing.T) {
 func minimalConfig() map[string]interface{} {
 	return map[string]interface{}{
 		"vcenter_server": "vcenter.domain.local",
-		"username":     "root",
-		"password":     "vmware",
-		"template":     "ubuntu",
-		"vm_name":      "vm1",
-		"host":         "esxi1.domain.local",
-		"ssh_username": "root",
-		"ssh_password": "secret",
+		"username":       "root",
+		"password":       "vmware",
+		"template":       "ubuntu",
+		"vm_name":        "vm1",
+		"host":           "esxi1.domain.local",
+		"ssh_username":   "root",
+		"ssh_password":   "secret",
 	}
 }
 

--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -1,12 +1,12 @@
 package clone
 
 import (
+	"context"
+	"fmt"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
-	"fmt"
-	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
-	"context"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 )
 
 type CloneConfig struct {

--- a/common/config_ssh.go
+++ b/common/config_ssh.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 
 	packerssh "github.com/hashicorp/packer/communicator/ssh"
+	"github.com/hashicorp/packer/helper/communicator"
 	"github.com/hashicorp/packer/helper/multistep"
 	"golang.org/x/crypto/ssh"
-	"github.com/hashicorp/packer/helper/communicator"
 )
 
 func CommHost(state multistep.StateBag) (string, error) {

--- a/common/step_config_params.go
+++ b/common/step_config_params.go
@@ -1,11 +1,11 @@
 package common
 
 import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
-	"fmt"
-	"context"
 )
 
 type ConfigParamsConfig struct {

--- a/common/step_connect.go
+++ b/common/step_connect.go
@@ -1,10 +1,10 @@
 package common
 
 import (
-	"github.com/hashicorp/packer/helper/multistep"
-	"fmt"
-	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"context"
+	"fmt"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 )
 
 type ConnectConfig struct {

--- a/common/step_hardware.go
+++ b/common/step_hardware.go
@@ -1,25 +1,25 @@
 package common
 
 import (
-	"github.com/hashicorp/packer/packer"
-	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
 	"context"
 	"fmt"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 )
 
 type HardwareConfig struct {
-	CPUs                int32 `mapstructure:"CPUs"`
-	CPUReservation      int64 `mapstructure:"CPU_reservation"`
-	CPULimit            int64 `mapstructure:"CPU_limit"`
-	CpuHotAddEnabled    bool  `mapstructure:"CPU_hot_plug"`
+	CPUs             int32 `mapstructure:"CPUs"`
+	CPUReservation   int64 `mapstructure:"CPU_reservation"`
+	CPULimit         int64 `mapstructure:"CPU_limit"`
+	CpuHotAddEnabled bool  `mapstructure:"CPU_hot_plug"`
 
 	RAM                 int64 `mapstructure:"RAM"`
 	RAMReservation      int64 `mapstructure:"RAM_reservation"`
 	RAMReserveAll       bool  `mapstructure:"RAM_reserve_all"`
 	MemoryHotAddEnabled bool  `mapstructure:"RAM_hot_plug"`
 
-	NestedHV            bool  `mapstructure:"NestedHV"`
+	NestedHV bool `mapstructure:"NestedHV"`
 }
 
 func (c *HardwareConfig) Prepare() []error {
@@ -27,6 +27,10 @@ func (c *HardwareConfig) Prepare() []error {
 
 	if c.RAMReservation > 0 && c.RAMReserveAll != false {
 		errs = append(errs, fmt.Errorf("'RAM_reservation' and 'RAM_reserve_all' cannot be used together"))
+	}
+
+	if c.CPULimit == 0 {
+		c.CPULimit = -1
 	}
 
 	return errs

--- a/common/step_remove_network_card.go
+++ b/common/step_remove_network_card.go
@@ -1,0 +1,38 @@
+package common
+
+import (
+	"context"
+	"github.com/hashicorp/packer/helper/multistep"
+	"github.com/hashicorp/packer/packer"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type StepRemoveNetworkCard struct {
+	RemoveNetworkCard bool
+}
+
+func (s *StepRemoveNetworkCard) Run(_ context.Context, state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	vm := state.Get("vm").(*driver.VirtualMachine)
+
+	if s.RemoveNetworkCard {
+		ui.Say("Deleting Network Cards...")
+		devices, err := vm.Devices()
+		if err != nil {
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+
+		cards := devices.SelectByType((*types.VirtualEthernetCard)(nil))
+
+		if err = vm.RemoveDevice(true, cards...); err != nil {
+			state.Put("error", err)
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepRemoveNetworkCard) Cleanup(state multistep.StateBag) {}

--- a/common/step_run.go
+++ b/common/step_run.go
@@ -1,11 +1,11 @@
 package common
 
 import (
+	"context"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"strings"
-	"context"
 )
 
 type RunConfig struct {
@@ -40,7 +40,7 @@ func (s *StepRun) Run(_ context.Context, state multistep.StateBag) multistep.Ste
 	ui.Say("Power on VM...")
 	err := vm.PowerOn()
 	if err != nil {
-		state.Put("error",err)
+		state.Put("error", err)
 		return multistep.ActionHalt
 	}
 

--- a/common/step_shutdown.go
+++ b/common/step_shutdown.go
@@ -1,21 +1,21 @@
 package common
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
-	"fmt"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"log"
 	"time"
-	"bytes"
-	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"context"
 )
 
 type ShutdownConfig struct {
 	Command    string `mapstructure:"shutdown_command"`
 	RawTimeout string `mapstructure:"shutdown_timeout"`
 
-	Timeout    time.Duration
+	Timeout time.Duration
 }
 
 func (c *ShutdownConfig) Prepare() []error {

--- a/common/step_snapshot.go
+++ b/common/step_snapshot.go
@@ -1,13 +1,13 @@
 package common
 
 import (
+	"context"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"context"
 )
 
-type StepCreateSnapshot struct{
+type StepCreateSnapshot struct {
 	CreateSnapshot bool
 }
 

--- a/common/step_template.go
+++ b/common/step_template.go
@@ -1,13 +1,13 @@
 package common
 
 import (
+	"context"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"context"
 )
 
-type StepConvertToTemplate struct{
+type StepConvertToTemplate struct {
 	ConvertToTemplate bool
 }
 

--- a/common/step_wait_for_ip.go
+++ b/common/step_wait_for_ip.go
@@ -1,12 +1,12 @@
 package common
 
 import (
-	"github.com/hashicorp/packer/helper/multistep"
+	"context"
 	"fmt"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"time"
-	"context"
 )
 
 type StepWaitForIp struct{}

--- a/common/testing/utility.go
+++ b/common/testing/utility.go
@@ -1,14 +1,14 @@
 package testing
 
 import (
-	"fmt"
-	"math/rand"
-	"time"
 	"encoding/json"
+	"fmt"
 	"github.com/hashicorp/packer/packer"
-	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"testing"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
+	"math/rand"
+	"testing"
+	"time"
 )
 
 func NewVMName() string {
@@ -31,7 +31,6 @@ func RenderConfig(config map[string]interface{}) string {
 	j, _ := json.Marshal(t)
 	return string(j)
 }
-
 
 func TestConn(t *testing.T) *driver.Driver {
 	d, err := driver.NewDriver(&driver.ConnectConfig{
@@ -57,4 +56,3 @@ func GetVM(t *testing.T, d *driver.Driver, artifacts []packer.Artifact) *driver.
 
 	return vm
 }
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,5 @@ services:
     volumes:
       - .:/go/src/github.com/jetbrains-infra/packer-builder-vsphere
     working_dir: /go/src/github.com/jetbrains-infra/packer-builder-vsphere
-#    network_mode: "container:vpn"
     command: ./test.sh
+#    network_mode: "container:vpn"

--- a/driver/datastore.go
+++ b/driver/datastore.go
@@ -1,11 +1,11 @@
 package driver
 
 import (
+	"fmt"
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
-	"fmt"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 type Datastore struct {

--- a/driver/driver.go
+++ b/driver/driver.go
@@ -1,16 +1,16 @@
 package driver
 
 import (
+	"context"
+	"fmt"
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
-	"context"
-	"net/url"
-	"fmt"
 	"github.com/vmware/govmomi/object"
-	"time"
 	"github.com/vmware/govmomi/session"
-	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/soap"
+	"net/url"
+	"time"
 )
 
 type Driver struct {

--- a/driver/driver_test.go
+++ b/driver/driver_test.go
@@ -2,9 +2,9 @@ package driver
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
-	"math/rand"
 )
 
 // Defines whether acceptance tests should be run

--- a/driver/folder.go
+++ b/driver/folder.go
@@ -1,10 +1,10 @@
 package driver
 
 import (
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/govmomi/vim25/mo"
 	"fmt"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 type Folder struct {

--- a/driver/host.go
+++ b/driver/host.go
@@ -2,18 +2,18 @@ package driver
 
 import (
 	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 type Host struct {
 	driver *Driver
-	host *object.HostSystem
+	host   *object.HostSystem
 }
 
 func (d *Driver) NewHost(ref *types.ManagedObjectReference) *Host {
 	return &Host{
-		host: object.NewHostSystem(d.client.Client, *ref),
+		host:   object.NewHostSystem(d.client.Client, *ref),
 		driver: d,
 	}
 }
@@ -29,7 +29,7 @@ func (d *Driver) FindHost(name string) (*Host, error) {
 	}, nil
 }
 
-func (h *Host) Info(params ...string) (*mo.HostSystem, error){
+func (h *Host) Info(params ...string) (*mo.HostSystem, error) {
 	var p []string
 	if len(params) == 0 {
 		p = []string{"*"}

--- a/driver/resource_pool.go
+++ b/driver/resource_pool.go
@@ -1,10 +1,10 @@
 package driver
 
 import (
-	"github.com/vmware/govmomi/object"
-	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/govmomi/vim25/mo"
 	"fmt"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 type ResourcePool struct {
@@ -32,7 +32,7 @@ func (d *Driver) FindResourcePool(cluster string, host string, name string) (*Re
 		return nil, err
 	}
 	return &ResourcePool{
-		pool: p,
+		pool:   p,
 		driver: d,
 	}, nil
 }

--- a/driver/resource_pool_acc_test.go
+++ b/driver/resource_pool_acc_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestResourcePoolAcc(t *testing.T) {
 	d := newTestDriver(t)
-	p, err := d.FindResourcePool("","esxi-1.vsphere65.test", "pool1/pool2")
+	p, err := d.FindResourcePool("", "esxi-1.vsphere65.test", "pool1/pool2")
 	if err != nil {
 		t.Fatalf("Cannot find the default resource pool '%v': %v", "pool1/pool2", err)
 	}

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -1,14 +1,14 @@
 package driver
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"time"
 	"strings"
-	"context"
+	"time"
 )
 
 type VirtualMachine struct {

--- a/driver/vm_cdrom.go
+++ b/driver/vm_cdrom.go
@@ -1,8 +1,8 @@
 package driver
 
 import (
-	"github.com/vmware/govmomi/vim25/types"
 	"errors"
+	"github.com/vmware/govmomi/vim25/types"
 )
 
 func (vm *VirtualMachine) AddSATAController() error {

--- a/driver/vm_clone_acc_test.go
+++ b/driver/vm_clone_acc_test.go
@@ -1,11 +1,11 @@
 package driver
 
 import (
+	"context"
 	"log"
 	"net"
 	"testing"
 	"time"
-	"context"
 )
 
 func TestVMAcc_clone(t *testing.T) {
@@ -168,7 +168,7 @@ func configureCheck(t *testing.T, vm *VirtualMachine, _ *CloneConfig) {
 
 func configureRAMReserveAllCheck(t *testing.T, vm *VirtualMachine, _ *CloneConfig) {
 	log.Printf("[DEBUG] Configuring the vm")
-	vm.Configure(&HardwareConfig{ RAMReserveAll: true })
+	vm.Configure(&HardwareConfig{RAMReserveAll: true})
 
 	log.Printf("[DEBUG] Running checks")
 	vmInfo, err := vm.Info("config")
@@ -237,7 +237,7 @@ func startAndStopCheck(t *testing.T, vm *VirtualMachine, config *CloneConfig) {
 
 	vm.StartShutdown()
 	log.Printf("[DEBUG] Waiting max 1m0s for shutdown to complete")
-	vm.WaitForShutdown(context.TODO(), 1 * time.Minute)
+	vm.WaitForShutdown(context.TODO(), 1*time.Minute)
 }
 
 func snapshotCheck(t *testing.T, vm *VirtualMachine, config *CloneConfig) {

--- a/driver/vm_keyboard.go
+++ b/driver/vm_keyboard.go
@@ -1,11 +1,11 @@
 package driver
 
 import (
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+	"golang.org/x/mobile/event/key"
 	"strings"
 	"unicode"
-	"github.com/vmware/govmomi/vim25/types"
-	"github.com/vmware/govmomi/vim25/methods"
-	"golang.org/x/mobile/event/key"
 )
 
 type KeyInput struct {
@@ -26,9 +26,9 @@ func init() {
 	scancodeIndex["!@#$%^&*()"] = key.Code1
 	scancodeIndex[" "] = key.CodeSpacebar
 	scancodeIndex["-=[]\\"] = key.CodeHyphenMinus
-	scancodeIndex["_+{}|" ] = key.CodeHyphenMinus
-	scancodeIndex[ ";'`,./" ] = key.CodeSemicolon
-	scancodeIndex[":\"~<>?" ] = key.CodeSemicolon
+	scancodeIndex["_+{}|"] = key.CodeHyphenMinus
+	scancodeIndex[";'`,./"] = key.CodeSemicolon
+	scancodeIndex[":\"~<>?"] = key.CodeSemicolon
 
 	for chars, start := range scancodeIndex {
 		for i, r := range chars {

--- a/examples/centos7/centos-7.json
+++ b/examples/centos7/centos-7.json
@@ -1,0 +1,61 @@
+{
+  "builders": [
+    {
+      "type": "vsphere-iso",
+      "vm_version": 13,
+      "vcenter_server":      "vcenter.admin",
+      "username":            "administrator@vcenter.admin",
+      "password":            "password",
+      "insecure_connection": "true",
+      "datacenter" : "datacenter",
+      "vm_name": "test-template-centos-7",
+      "cluster" : "cluster",
+      "host" : "192.168.15.8",
+      
+      "guest_os_type": "rhel7_64Guest",
+
+      "communicator": "ssh",
+      "ssh_username": "root",
+      "ssh_password": "root",
+
+      "CPUs":             1,
+      "CPU_limit":        -1,
+      "RAM":              2048,
+
+      "convert_to_template": true,
+      "remove_network_card": true,
+
+      "disk_size":        10240,
+      "disk_thin_provisioned": true,
+      "disk_controller_type": "pvscsi",
+
+      "network_card": "vmxnet3",
+      "network": "677-in1-vmadm",
+
+      "iso_paths": [
+        "[par3-c1-pve-1] ISO/CentOS-7-x86_64-Minimal-1804.iso"
+      ],
+
+      "floppy_files": [
+        "{{template_dir}}/ks.cfg"
+      ],
+
+      "boot_wait": "10s",
+
+      "boot_command": [
+        "<tab>",
+        " text inst.ks=hd:fd0:/ks.cfg net.ifnames=0 biosdevname=0",
+        "<wait>",
+        "<enter>",
+        "<wait>",
+        "<enter>"
+      ]
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": ["ip a"]
+    }
+  ]
+}

--- a/examples/centos7/ks.cfg
+++ b/examples/centos7/ks.cfg
@@ -1,0 +1,62 @@
+# Turning on text-mode installation (little quicker than GUI)
+text
+
+# Setting up authentication and keyboard
+auth --enableshadow --passalgo=sha512
+keyboard --vckeymap=us --xlayouts='us'
+
+# Installation files source (CentOS-7.0-1406-x86_64-Minimal.iso)
+cdrom
+
+# Using only primary disk, ignoring others
+ignoredisk --only-use=sda
+
+# Setting up language to English
+lang en-US.UTF-8
+
+# Setting up network interface to DHCP
+network --bootproto=static --ip=192.168.1.15 --netmask=255.255.255.0 --gateway=192.168.1.254 --nameserver=8.8.8.8 --hostname=test-template-centos-7 --activate
+
+# Root password (remember that plaintext only for information purposes)
+rootpw --plaintext root
+
+#Disable firewall
+firewall --disabled
+
+# Setting timezone
+timezone UTC --utc
+
+# Setting up Security-Enhanced Linux into enforcing
+selinux --disabled
+
+# Setting up MBR
+bootloader --location=mbr --boot-drive=sda
+
+# Setting up Logical Volume Manager and autopartitioning
+clearpart --all --drives=sda --initlabel
+part / --grow --fstype=xfs --asprimary --ondisk=sda
+
+#Enabled SSHD at boot
+services --enabled=sshd
+
+#REPO
+repo --name="CentOS" --baseurl="http://mirror.centos.org/centos/$releasever/os/$basearch/"
+repo --name="epel" --baseurl="http://download.fedoraproject.org/pub/epel/7/$basearch"
+
+# Eject cdrom and reboot
+reboot --eject
+
+# Installing only packages for minimal install 
+%packages
+@Core
+epel-release
+open-vm-tools
+%end
+
+#Enable Root login for SSHD
+%post --log=/root/ks.log
+augtool -s <<EOF
+set /files/etc/ssh/sshd_config/PermitRootLogin yes
+set /files/etc/ssh/sshd_config/PasswordAuthentication yes
+EOF
+%end

--- a/examples/driver/main.go
+++ b/examples/driver/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"fmt"
 	"context"
+	"fmt"
+	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 )
 
 func main() {

--- a/iso/builder.go
+++ b/iso/builder.go
@@ -2,11 +2,11 @@ package iso
 
 import (
 	packerCommon "github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
-	"github.com/hashicorp/packer/helper/communicator"
 )
 
 type Builder struct {
@@ -87,6 +87,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 
 	steps = append(steps,
+		&common.StepRemoveNetworkCard{
+			RemoveNetworkCard: b.config.RemoveNetworkCard,
+		},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
 		},

--- a/iso/builder_acc_test.go
+++ b/iso/builder_acc_test.go
@@ -1,13 +1,13 @@
 package iso
 
 import (
-	builderT "github.com/hashicorp/packer/helper/builder/testing"
-	commonT "github.com/jetbrains-infra/packer-builder-vsphere/common/testing"
-	"testing"
-	"github.com/hashicorp/packer/packer"
-	"github.com/vmware/govmomi/vim25/types"
 	"fmt"
+	builderT "github.com/hashicorp/packer/helper/builder/testing"
+	"github.com/hashicorp/packer/packer"
+	commonT "github.com/jetbrains-infra/packer-builder-vsphere/common/testing"
+	"github.com/vmware/govmomi/vim25/types"
 	"io/ioutil"
+	"testing"
 )
 
 func TestISOBuilderAcc_default(t *testing.T) {

--- a/iso/config.go
+++ b/iso/config.go
@@ -3,10 +3,10 @@ package iso
 import (
 	packerCommon "github.com/hashicorp/packer/common"
 	"github.com/hashicorp/packer/helper/communicator"
+	"github.com/hashicorp/packer/helper/config"
 	"github.com/hashicorp/packer/packer"
 	"github.com/hashicorp/packer/template/interpolate"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
-	"github.com/hashicorp/packer/helper/config"
 )
 
 type Config struct {
@@ -18,15 +18,16 @@ type Config struct {
 	common.HardwareConfig     `mapstructure:",squash"`
 	common.ConfigParamsConfig `mapstructure:",squash"`
 
-	CDRomConfig              `mapstructure:",squash"`
-	FloppyConfig             `mapstructure:",squash"`
-	common.RunConfig         `mapstructure:",squash"`
-	BootConfig               `mapstructure:",squash"`
-	Comm communicator.Config `mapstructure:",squash"`
-	common.ShutdownConfig    `mapstructure:",squash"`
+	CDRomConfig           `mapstructure:",squash"`
+	FloppyConfig          `mapstructure:",squash"`
+	common.RunConfig      `mapstructure:",squash"`
+	BootConfig            `mapstructure:",squash"`
+	Comm                  communicator.Config `mapstructure:",squash"`
+	common.ShutdownConfig `mapstructure:",squash"`
 
 	CreateSnapshot    bool `mapstructure:"create_snapshot"`
 	ConvertToTemplate bool `mapstructure:"convert_to_template"`
+	RemoveNetworkCard bool `mapstructure:"remove_network_card"`
 
 	ctx interpolate.Context
 }

--- a/iso/step_add_cdrom.go
+++ b/iso/step_add_cdrom.go
@@ -1,11 +1,11 @@
 package iso
 
 import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
-	"fmt"
-	"context"
 )
 
 type CDRomConfig struct {

--- a/iso/step_add_floppy.go
+++ b/iso/step_add_floppy.go
@@ -1,11 +1,11 @@
 package iso
 
 import (
+	"context"
+	"fmt"
 	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"fmt"
-	"context"
 )
 
 type FloppyConfig struct {

--- a/iso/step_boot_command.go
+++ b/iso/step_boot_command.go
@@ -1,18 +1,18 @@
 package iso
 
 import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/packer/common"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
-	"fmt"
-	"time"
-	"strings"
 	"golang.org/x/mobile/event/key"
-	"unicode/utf8"
-	"github.com/hashicorp/packer/common"
-	"os"
 	"log"
-	"context"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
 )
 
 type BootConfig struct {

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -1,12 +1,12 @@
 package iso
 
 import (
+	"context"
 	"fmt"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/common"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
-	"context"
 )
 
 type CreateConfig struct {

--- a/iso/step_remove_cdrom.go
+++ b/iso/step_remove_cdrom.go
@@ -1,11 +1,11 @@
 package iso
 
 import (
+	"context"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/vmware/govmomi/vim25/types"
-	"context"
 )
 
 type StepRemoveCDRom struct{}

--- a/iso/step_remove_floppy.go
+++ b/iso/step_remove_floppy.go
@@ -1,11 +1,11 @@
 package iso
 
 import (
+	"context"
+	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
-	"github.com/hashicorp/packer/helper/multistep"
 	"github.com/vmware/govmomi/vim25/types"
-	"context"
 )
 
 type StepRemoveFloppy struct {


### PR DESCRIPTION
Hello,

Multiple things in this PR, sorry if this is too big

- Fix Gopkg.toml, apparently the syntax of version wasn't right and I had a build error about a commit that didn't exist anymore (i'm guessing the commit was squash from a PR)

- add gofmt to build.sh, the majority of change in this PR came from this

- add the configurable step "remove_network_card" that remove all network cards from the instance after shutdown and before snapshot/template

- add build instruction to README.md

- CPU_limit set to -1 by default, otherwise 0 is set and the virtual machine freeze (fixing https://github.com/jetbrains-infra/packer-builder-vsphere/issues/136, https://github.com/jetbrains-infra/packer-builder-vsphere/issues/119)

- add a examples for building a centos7 template