### PR TITLE
#138 Add firmware option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `network`(string) - Set network VM will be connected to.
 * `network_card`(string) - Set VM network card type. Example `vmxnet3`.
 * `usb_controller`(boolean) - Create US controller for virtual machine. Defaults to `false`.
+* `firmware`(string) - Set the Firmware at machine creation. Example `efi`. Defaults to `bios`
 
 ### Boot (`vsphere-iso` only)
 

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -55,6 +55,7 @@ type CreateConfig struct {
 	NetworkCard   string // example: vmxnet3
 	USBController bool
 	Version       uint // example: 10
+	Firmware      string // efi or bios
 }
 
 func (d *Driver) NewVM(ref *types.ManagedObjectReference) *VirtualMachine {
@@ -80,6 +81,7 @@ func (d *Driver) CreateVM(config *CreateConfig) (*VirtualMachine, error) {
 		Name:       config.Name,
 		Annotation: config.Annotation,
 		GuestId:    config.GuestOS,
+		Firmware:   config.Firmware,
 	}
 	if config.Version != 0 {
 		createSpec.Version = fmt.Sprintf("%s%d", "vmx-", config.Version)

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -12,6 +12,7 @@ import (
 type CreateConfig struct {
 	Version     uint   `mapstructure:"vm_version"`
 	GuestOSType string `mapstructure:"guest_os_type"`
+	Firmware    string `mapstructure:"firmware"`
 
 	DiskControllerType  string `mapstructure:"disk_controller_type"`
 	DiskSize            int64  `mapstructure:"disk_size"`
@@ -31,6 +32,10 @@ func (c *CreateConfig) Prepare() []error {
 
 	if c.GuestOSType == "" {
 		c.GuestOSType = "otherGuest"
+	}
+
+	if (c.Firmware == "") {
+		c.Firmware = "bios"
 	}
 
 	return errs
@@ -61,6 +66,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 		NetworkCard:         s.Config.NetworkCard,
 		USBController:       s.Config.USBController,
 		Version:             s.Config.Version,
+		Firmware:            s.Config.Firmware,
 	})
 	if err != nil {
 		state.Put("error", fmt.Errorf("error creating vm: %v", err))


### PR DESCRIPTION
Proposed PR to address #138

Add "firmware" as an option for the hardware section, allowing values of
"efi" or "bios" (default "bios") so that the firmware is defined at the
machine create stage.
