### PR TITLE
Fix default CPU limit

### DIFF
--- a/driver/vm.go
+++ b/driver/vm.go
@@ -255,7 +255,9 @@ func (vm *VirtualMachine) Configure(config *HardwareConfig) error {
 
 	var cpuSpec types.ResourceAllocationInfo
 	cpuSpec.Reservation = &config.CPUReservation
-	cpuSpec.Limit = &config.CPULimit
+	if config.CPULimit != 0 {
+		cpuSpec.Limit = &config.CPULimit
+	}
 	confSpec.CpuAllocation = &cpuSpec
 
 	var ramSpec types.ResourceAllocationInfo


### PR DESCRIPTION
fix #119.

govmomi 0.17 (https://github.com/jetbrains-infra/packer-builder-vsphere/commit/903febc4ea8ab540e7bd4a3d235e32346076c2ca) changed a behavior: previously setting `CPULimit` to 0 was ignorred, now it's applied as is.

Now CPU limit is set to `Unlimited` by default.