### PR TITLE
Eject cdroms, don't delete

### DIFF
--- a/driver/vm_cdrom.go
+++ b/driver/vm_cdrom.go
@@ -46,3 +46,22 @@ func (vm *VirtualMachine) CreateCdrom(c *types.VirtualAHCIController) (*types.Vi
 
 	return device, nil
 }
+
+func (vm *VirtualMachine) EjectCdroms() error {
+	devices, err := vm.Devices()
+	if err != nil {
+		return err
+	}
+	cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
+	for _, cd := range cdroms {
+		c := cd.(*types.VirtualCdrom)
+		c.Backing = &types.VirtualCdromRemotePassthroughBackingInfo{}
+		c.Connectable = &types.VirtualDeviceConnectInfo{}
+		err := vm.vm.EditDevice(vm.driver.ctx, c)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/iso/builder_acc_test.go
+++ b/iso/builder_acc_test.go
@@ -353,6 +353,18 @@ func checkFull(t *testing.T) builderT.TestCheckFunc {
 			t.Errorf("Boot order must be empty")
 		}
 
+		devices, err := vm.Devices()
+		if err != nil {
+			t.Fatalf("Cannot read devices: %v", err)
+		}
+		cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
+		for _, cd := range cdroms {
+			_, ok := cd.(*types.VirtualCdrom).Backing.(*types.VirtualCdromRemotePassthroughBackingInfo)
+			if !ok {
+				t.Errorf("wrong cdrom backing")
+			}
+		}
+
 		return nil
 	}
 }

--- a/iso/step_remove_cdrom.go
+++ b/iso/step_remove_cdrom.go
@@ -4,7 +4,6 @@ import (
 	"github.com/hashicorp/packer/packer"
 	"github.com/jetbrains-infra/packer-builder-vsphere/driver"
 	"github.com/hashicorp/packer/helper/multistep"
-	"github.com/vmware/govmomi/vim25/types"
 	"context"
 )
 
@@ -14,21 +13,9 @@ func (s *StepRemoveCDRom) Run(_ context.Context, state multistep.StateBag) multi
 	ui := state.Get("ui").(packer.Ui)
 	vm := state.Get("vm").(*driver.VirtualMachine)
 
-	ui.Say("Deleting CD-ROM drives...")
-	devices, err := vm.Devices()
+	ui.Say("Eject CD-ROM drives...")
+	err := vm.EjectCdroms()
 	if err != nil {
-		state.Put("error", err)
-		return multistep.ActionHalt
-	}
-	cdroms := devices.SelectByType((*types.VirtualCdrom)(nil))
-	if err = vm.RemoveDevice(true, cdroms...); err != nil {
-		state.Put("error", err)
-		return multistep.ActionHalt
-	}
-
-	ui.Say("Deleting SATA controller...")
-	sata := devices.SelectByType((*types.VirtualAHCIController)(nil))
-	if err = vm.RemoveDevice(true, sata...); err != nil {
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}


### PR DESCRIPTION
fix #133 

ISO builder ejects CD-ROM images instead of deleting devices.