### PR TITLE
Optionally use SATA controller for CD-ROM devices

### DIFF
--- a/driver/vm_cdrom.go
+++ b/driver/vm_cdrom.go
@@ -24,7 +24,7 @@ func (vm *VirtualMachine) FindSATAController() (*types.VirtualAHCIController, er
 	return c.(*types.VirtualAHCIController), nil
 }
 
-func (vm *VirtualMachine) CreateCdrom(c *types.VirtualAHCIController) (*types.VirtualCdrom, error) {
+func (vm *VirtualMachine) CreateCdrom(c *types.VirtualController) (*types.VirtualCdrom, error) {
 	l, err := vm.Devices()
 	if err != nil {
 		return nil, err

--- a/examples/macos/macos-10.13.json
+++ b/examples/macos/macos-10.13.json
@@ -26,6 +26,7 @@
         "ich7m.present": "TRUE",
         "smc.present": "TRUE"
       },
+      "cdrom_type": "sata",
 
       "iso_paths": [
         "[datastore-mac] ISO/macOS 10.13.3.iso",

--- a/iso/builder.go
+++ b/iso/builder.go
@@ -43,6 +43,9 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 		&common.StepConfigureHardware{
 			Config: &b.config.HardwareConfig,
 		},
+		&StepAddCDRom{
+			Config: &b.config.CDRomConfig,
+		},
 		&common.StepConfigParams{
 			Config: &b.config.ConfigParamsConfig,
 		},
@@ -50,9 +53,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 
 	if b.config.Comm.Type != "none" {
 		steps = append(steps,
-			&StepAddCDRom{
-				Config: &b.config.CDRomConfig,
-			},
 			&packerCommon.StepCreateFloppy{
 				Files:       b.config.FloppyFiles,
 				Directories: b.config.FloppyDirectories,
@@ -79,7 +79,6 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 			&common.StepShutdown{
 				Config: &b.config.ShutdownConfig,
 			},
-			&StepRemoveCDRom{},
 			&StepRemoveFloppy{
 				Datastore: b.config.Datastore,
 				Host:      b.config.Host,
@@ -88,6 +87,7 @@ func (b *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packe
 	}
 
 	steps = append(steps,
+		&StepRemoveCDRom{},
 		&common.StepCreateSnapshot{
 			CreateSnapshot: b.config.CreateSnapshot,
 		},

--- a/iso/builder_acc_test.go
+++ b/iso/builder_acc_test.go
@@ -166,6 +166,19 @@ func checkHardware(t *testing.T) builderT.TestCheckFunc {
 			t.Errorf("Invalid firmware: expected 'efi', got '%v'", fw)
 		}
 
+		l, err := vm.Devices()
+		if err != nil {
+			t.Fatalf("Cannot read VM devices: %v", err)
+		}
+		c := l.PickController((*types.VirtualIDEController)(nil))
+		if c == nil {
+			t.Errorf("VM should have IDE controller")
+		}
+		s := l.PickController((*types.VirtualAHCIController)(nil))
+		if s != nil {
+			t.Errorf("VM should have no SATA controllers")
+		}
+
 		return nil
 	}
 }

--- a/iso/builder_acc_test.go
+++ b/iso/builder_acc_test.go
@@ -204,6 +204,41 @@ func checkLimit(t *testing.T) builderT.TestCheckFunc {
 	}
 }
 
+func TestISOBuilderAcc_sata(t *testing.T) {
+	builderT.Test(t, builderT.TestCase{
+		Builder:  &Builder{},
+		Template: sataConfig(),
+		Check:    checkSata(t),
+	})
+}
+
+func sataConfig() string {
+	config := defaultConfig()
+	config["cdrom_type"] = "sata"
+
+	return commonT.RenderConfig(config)
+}
+
+func checkSata(t *testing.T) builderT.TestCheckFunc {
+	return func(artifacts []packer.Artifact) error {
+		d := commonT.TestConn(t)
+
+		vm := commonT.GetVM(t, d, artifacts)
+
+		l, err := vm.Devices()
+		if err != nil {
+			t.Fatalf("Cannot read VM devices: %v", err)
+		}
+
+		c := l.PickController((*types.VirtualAHCIController)(nil))
+		if c == nil {
+			t.Errorf("VM has no SATA controllers")
+		}
+
+		return nil
+	}
+}
+
 func TestISOBuilderAcc_cdrom(t *testing.T) {
 	builderT.Test(t, builderT.TestCase{
 		Builder:  &Builder{},

--- a/iso/config.go
+++ b/iso/config.go
@@ -47,6 +47,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	errs = packer.MultiErrorAppend(errs, c.LocationConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
 
+	errs = packer.MultiErrorAppend(errs, c.CDRomConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare()...)


### PR DESCRIPTION
Fix #110.

By default CD-ROMs devices are linked to IDE controller.
New `"cdrom_type": "sata"` parameter allows creating SATA controller.