### PR TITLE
Cpu cores

### DIFF
--- a/clone/builder_acc_test.go
+++ b/clone/builder_acc_test.go
@@ -333,6 +333,7 @@ func TestCloneBuilderAcc_hardware(t *testing.T) {
 func hardwareConfig() string {
 	config := defaultConfig()
 	config["CPUs"] = 2
+	config["cpu_cores"] = 2
 	config["CPU_reservation"] = 1000
 	config["CPU_limit"] = 1500
 	config["RAM"] = 2048
@@ -357,6 +358,11 @@ func checkHardware(t *testing.T) builderT.TestCheckFunc {
 		cpuSockets := vmInfo.Config.Hardware.NumCPU
 		if cpuSockets != 2 {
 			t.Errorf("VM should have 2 CPU sockets, got %v", cpuSockets)
+		}
+
+		cpuCores := vmInfo.Config.Hardware.NumCoresPerSocket
+		if cpuCores != 2 {
+			t.Errorf("VM should have 2 CPU cores per socket, got %v", cpuCores)
 		}
 
 		cpuReservation := *vmInfo.Config.CpuAllocation.Reservation

--- a/common/step_hardware.go
+++ b/common/step_hardware.go
@@ -10,6 +10,7 @@ import (
 
 type HardwareConfig struct {
 	CPUs             int32 `mapstructure:"CPUs"`
+	CpuCores         int32 `mapstructure:"cpu_cores"`
 	CPUReservation   int64 `mapstructure:"CPU_reservation"`
 	CPULimit         int64 `mapstructure:"CPU_limit"`
 	CpuHotAddEnabled bool  `mapstructure:"CPU_hot_plug"`
@@ -46,6 +47,7 @@ func (s *StepConfigureHardware) Run(_ context.Context, state multistep.StateBag)
 
 		err := vm.Configure(&driver.HardwareConfig{
 			CPUs:                s.Config.CPUs,
+			CpuCores:            s.Config.CpuCores,
 			CPUReservation:      s.Config.CPUReservation,
 			CPULimit:            s.Config.CPULimit,
 			RAM:                 s.Config.RAM,

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -29,6 +29,7 @@ type CloneConfig struct {
 
 type HardwareConfig struct {
 	CPUs                int32
+	CpuCores            int32
 	CPUReservation      int64
 	CPULimit            int64
 	RAM                 int64
@@ -259,6 +260,7 @@ func (vm *VirtualMachine) Destroy() error {
 func (vm *VirtualMachine) Configure(config *HardwareConfig) error {
 	var confSpec types.VirtualMachineConfigSpec
 	confSpec.NumCPUs = config.CPUs
+	confSpec.NumCoresPerSocket = config.CpuCores
 	confSpec.MemoryMB = config.RAM
 
 	var cpuSpec types.ResourceAllocationInfo

--- a/iso/builder_acc_test.go
+++ b/iso/builder_acc_test.go
@@ -155,6 +155,7 @@ func TestISOBuilderAcc_hardware(t *testing.T) {
 func hardwareConfig() string {
 	config := defaultConfig()
 	config["CPUs"] = 2
+	config["cpu_cores"] = 2
 	config["CPU_reservation"] = 1000
 	config["CPU_limit"] = 1500
 	config["RAM"] = 2048
@@ -179,6 +180,11 @@ func checkHardware(t *testing.T) builderT.TestCheckFunc {
 		cpuSockets := vmInfo.Config.Hardware.NumCPU
 		if cpuSockets != 2 {
 			t.Errorf("VM should have 2 CPU sockets, got %v", cpuSockets)
+		}
+
+		cpuCores := vmInfo.Config.Hardware.NumCoresPerSocket
+		if cpuCores != 2 {
+			t.Errorf("VM should have 2 CPU cores per socket, got %v", cpuCores)
 		}
 
 		cpuReservation := *vmInfo.Config.CpuAllocation.Reservation


### PR DESCRIPTION
Fix #192.

`cpu_cores` parameter specifies a number of CPU cores per socket.