### PR TITLE
Support redefining network in vsphere-clone builder

### DIFF
--- a/clone/step_clone.go
+++ b/clone/step_clone.go
@@ -13,6 +13,7 @@ type CloneConfig struct {
 	Template    string `mapstructure:"template"`
 	DiskSize    int64  `mapstructure:"disk_size"`
 	LinkedClone bool   `mapstructure:"linked_clone"`
+	Network     string `mapstructure:"network"`
 	Notes       string `mapstructure:"notes"`
 }
 
@@ -68,6 +69,7 @@ func (s *StepCloneVM) Run(ctx context.Context, state multistep.StateBag) multist
 		ResourcePool: s.Location.ResourcePool,
 		Datastore:    s.Location.Datastore,
 		LinkedClone:  s.Config.LinkedClone,
+		Network:      s.Config.Network,
 		Annotation:   s.Config.Notes,
 	})
 	if err != nil {

--- a/driver/network.go
+++ b/driver/network.go
@@ -1,0 +1,45 @@
+package driver
+
+import (
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type Network struct {
+	driver  *Driver
+	network *object.Network
+}
+
+func (d *Driver) NewNetwork(ref *types.ManagedObjectReference) *Network {
+	return &Network{
+		network: object.NewNetwork(d.client.Client, *ref),
+		driver:  d,
+	}
+}
+
+func (d *Driver) FindNetwork(name string) (*Network, error) {
+	n, err := d.finder.Network(d.ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &Network{
+		network: n.(*object.Network),
+		driver:  d,
+	}, nil
+}
+
+func (n *Network) Info(params ...string) (*mo.Network, error) {
+	var p []string
+	if len(params) == 0 {
+		p = []string{"*"}
+	} else {
+		p = params
+	}
+	var info mo.Network
+	err := n.network.Properties(n.driver.ctx, n.network.Reference(), p, &info)
+	if err != nil {
+		return nil, err
+	}
+	return &info, nil
+}

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -231,11 +231,11 @@ func (template *VirtualMachine) Clone(ctx context.Context, config *CloneConfig) 
 	}
 
 	if config.Network != "" {
-		net, err := template.driver.finder.Network(ctx, config.Network)
+		net, err := template.driver.FindNetwork(config.Network)
 		if err != nil {
 			return nil, err
 		}
-		backing, err := net.EthernetCardBackingInfo(ctx)
+		backing, err := net.network.EthernetCardBackingInfo(ctx)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We're using `vsphere-clone` to clone templates onto another host, unfortunately it has different available network, so it should be changed.

Now Packer builds hangs indefinitely on 'Waiting for IP...' step since VM started with old network and it's not connected.