### PR TITLE
add option to scrub disks

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `guest_os_type`(string) - Set VM OS type. Defaults to `otherGuest`. See [here](https://pubs.vmware.com/vsphere-6-5/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.vm.GuestOsDescriptor.GuestOsIdentifier.html) for a full list of possible values.
 * `disk_controller_type`(string) - Set VM disk controller type. Example `pvscsi`.
 * `disk_thin_provisioned`(boolean) - Enable VMDK thin provisioning for VM. Defaults to `false`.
+* `disk_eagerly_scrub`(boolean) - Enable VMDK eager scrubbing. Defaults to `false`.
+* `network`(string) - Set network VM will be connected to.
 * `network_card`(string) - Set VM network card type. Example `vmxnet3`.
 * `usb_controller`(boolean) - Create USB controller for virtual machine. Defaults to `false`.
 * `cdrom_type`(string) - Which controller to use. Example `sata`. Defaults to `ide`.

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -45,6 +45,7 @@ type HardwareConfig struct {
 
 type CreateConfig struct {
 	DiskThinProvisioned bool
+	DiskEagerlyScrub    bool
 	DiskControllerType  string // example: "scsi", "pvscsi"
 	DiskSize            int64
 
@@ -496,6 +497,7 @@ func addDisk(_ *Driver, devices object.VirtualDeviceList, config *CreateConfig) 
 			Backing: &types.VirtualDiskFlatVer2BackingInfo{
 				DiskMode:        string(types.VirtualDiskModePersistent),
 				ThinProvisioned: types.NewBool(config.DiskThinProvisioned),
+				EagerlyScrub:    types.NewBool(config.DiskEagerlyScrub),
 			},
 		},
 		CapacityInKB: config.DiskSize * 1024,

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -17,6 +17,7 @@ type CreateConfig struct {
 	DiskControllerType  string `mapstructure:"disk_controller_type"`
 	DiskSize            int64  `mapstructure:"disk_size"`
 	DiskThinProvisioned bool   `mapstructure:"disk_thin_provisioned"`
+	DiskEagerlyScrub    bool   `mapstructure:"disk_eagerly_scrub"`
 
 	Network       string `mapstructure:"network"`
 	NetworkCard   string `mapstructure:"network_card"`
@@ -69,6 +70,7 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 	ui.Say("Creating VM...")
 	vm, err = d.CreateVM(&driver.CreateConfig{
 		DiskThinProvisioned: s.Config.DiskThinProvisioned,
+		DiskEagerlyScrub:    s.Config.DiskEagerlyScrub,
 		DiskControllerType:  s.Config.DiskControllerType,
 		DiskSize:            s.Config.DiskSize,
 		Name:                s.Location.VMName,


### PR DESCRIPTION
Currently there is no option to create eagerly zeroed / scrubbed disks. 

This PR adds an option called `disk_eagerly_scrub` (default: `false`) which when enabled ensures that the disk is completely scrubbed before using it.