### PR TITLE
Allow MAC to be assigned to the primary nic at creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `disk_controller_type`(string) - Set VM disk controller type. Example `pvscsi`.
 * `disk_thin_provisioned`(boolean) - Enable VMDK thin provisioning for VM. Defaults to `false`.
 * `network_card`(string) - Set VM network card type. Example `vmxnet3`.
+* `mac_address_type`(string) - Should the MAC be generated? Examples `generated` or `manual`. Defaults to `generated`.
+* `mac_address`(string) - The MAC to assign the VM if `manual` is set on `mac_address_type`. 
 * `usb_controller`(boolean) - Create USB controller for virtual machine. Defaults to `false`.
 * `cdrom_type`(string) - Which controller to use. Example `sata`. Defaults to `ide`.
 * `firmware`(string) - Set the Firmware at machine creation. Example `efi`. Defaults to `bios`.

--- a/driver/vm.go
+++ b/driver/vm.go
@@ -58,6 +58,8 @@ type CreateConfig struct {
 	GuestOS       string // example: otherGuest
 	Network       string // "" for default network
 	NetworkCard   string // example: vmxnet3
+	MacAddressType  string
+	MacAddress    string
 	USBController bool
 	Version       uint   // example: 10
 	Firmware      string // efi or bios
@@ -542,6 +544,10 @@ func addNetwork(d *Driver, devices object.VirtualDeviceList, config *CreateConfi
 	if err != nil {
 		return nil, err
 	}
+
+	card := device.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+	card.MacAddress = config.MacAddress
+	card.AddressType =  config.MacAddressType
 
 	return append(devices, device), nil
 }

--- a/iso/builder_acc_test.go
+++ b/iso/builder_acc_test.go
@@ -338,6 +338,8 @@ func TestISOBuilderAcc_networkCard(t *testing.T) {
 func networkCardConfig() string {
 	config := defaultConfig()
 	config["network_card"] = "vmxnet3"
+	config["mac_address_type"] = "Generated"
+	config["mac_address"] = ""
 	return commonT.RenderConfig(config)
 }
 
@@ -425,6 +427,8 @@ func fullConfig() map[string]interface{} {
 		"disk_size":             1024,
 		"disk_thin_provisioned": true,
 		"network_card":          "vmxnet3",
+		"mac_address_type":          "generated",
+		"mac_address":          "",
 		"guest_os_type":         "other3xLinux64Guest",
 
 		"iso_paths": []string{

--- a/iso/step_create.go
+++ b/iso/step_create.go
@@ -20,6 +20,8 @@ type CreateConfig struct {
 
 	Network       string `mapstructure:"network"`
 	NetworkCard   string `mapstructure:"network_card"`
+	MacAddressType string `mapstructure:"mac_address_type"`
+	MacAddress string `mapstructure:"mac_address"`
 	USBController bool   `mapstructure:"usb_controller"`
 
 	Notes string `mapstructure:"notes"`
@@ -80,6 +82,8 @@ func (s *StepCreateVM) Run(_ context.Context, state multistep.StateBag) multiste
 		GuestOS:             s.Config.GuestOSType,
 		Network:             s.Config.Network,
 		NetworkCard:         s.Config.NetworkCard,
+		MacAddressType:      s.Config.MacAddressType,
+		MacAddress:          s.Config.MacAddress,
 		USBController:       s.Config.USBController,
 		Version:             s.Config.Version,
 		Firmware:            s.Config.Firmware,


### PR DESCRIPTION
This creates two new options that allow you to assign the MAC on the primary nic at creation time.  References #243. 