### PR TITLE
boot_command for clone builder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `cdrom_type`(string) - Which controller to use. Example `sata`. Defaults to `ide`.
 * `firmware`(string) - Set the Firmware at machine creation. Example `efi`. Defaults to `bios`.
 
+### Boot
+
+* `http_directory`(string) - Path to a directory to serve using a local HTTP server. Beware of [limitations](https://github.com/jetbrains-infra/packer-builder-vsphere/issues/108#issuecomment-449634324).
+* `http_ip`(string) - Specify IP address on which the HTTP server is started. If not provided the first non-loopback interface is used.
+* `http_port_min` and `http_port_max` as in other [builders](https://www.packer.io/docs/builders/virtualbox-iso.html#http_port_min).
+* `boot_wait`(string) Amount of time to wait for the VM to boot. Examples 45s and 10m. Defaults to 10 seconds. See [format](https://golang.org/pkg/time/#ParseDuration).
+* `boot_command`(array of strings) - List of commands to type when the VM is first booted. Used to initalize the operating system installer. See details in [Packer docs](https://www.packer.io/docs/builders/virtualbox-iso.html#boot-command).
 
 ### Boot (`vsphere-iso` only)
 
@@ -96,15 +103,10 @@ See complete Ubuntu, Windows, and macOS templates in the [examples folder](https
 * `floppy_files`(array of strings) - List of local files to be mounted to the VM floppy drive. Can be used to make Debian preseed or RHEL kickstart files available to the VM.
 * `floppy_dirs`(array of strings) - List of directories to copy files from.
 * `floppy_img_path`(string) - Datastore path to a floppy image that will be mounted to the VM. Example `[datastore1] ISO/pvscsi-Windows8.flp`.
-* `http_directory`(string) - Path to a directory to serve using a local HTTP server. Beware of [limitations](https://github.com/jetbrains-infra/packer-builder-vsphere/issues/108#issuecomment-449634324).
-* `http_ip`(string) - Specify IP address on which the HTTP server is started. If not provided the first non-loopback interface is used.
-* `http_port_min` and `http_port_max` as in other [builders](https://www.packer.io/docs/builders/virtualbox-iso.html#http_port_min).
 * `iso_urls`(array of strings) - Multiple URLs for the ISO to download. Packer will try these in order. If anything goes wrong attempting to download or while downloading a single URL, it will move on to the next. All URLs must point to the same file (same checksum). By default this is empty and iso_url is used. Only one of iso_url or iso_urls can be specified.
 * `iso_checksum `(string) - The checksum for the OS ISO file. Because ISO files are so large, this is required and Packer will verify it prior to booting a virtual machine with the ISO attached. The type of the checksum is specified with iso_checksum_type, documented below. At least one of iso_checksum and iso_checksum_url must be defined. This has precedence over iso_checksum_url type.
 * `iso_checksum_type`(string) - The type of the checksum specified in iso_checksum. Valid values are none, md5, sha1, sha256, or sha512 currently. While none will skip checksumming, this is not recommended since ISO files are generally large and corruption does happen from time to time.
 * `iso_checksum_url`(string) -  A URL to a GNU or BSD style checksum file containing a checksum for the OS ISO file. At least one of iso_checksum and iso_checksum_url must be defined. This will be ignored if iso_checksum is non empty.
-* `boot_wait`(string) Amount of time to wait for the VM to boot. Examples 45s and 10m. Defaults to 10 seconds. See [format](https://golang.org/pkg/time/#ParseDuration).
-* `boot_command`(array of strings) - List of commands to type when the VM is first booted. Used to initalize the operating system installer. See details in [Packer docs](https://www.packer.io/docs/builders/virtualbox-iso.html#boot-command).
 
 ### Provision
 

--- a/clone/builder.go
+++ b/clone/builder.go
@@ -52,6 +52,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 
 	if b.config.Comm.Type != "none" {
 		steps = append(steps,
+			&packerCommon.StepHTTPServer{
+				HTTPDir:     b.config.HTTPDir,
+				HTTPPortMin: b.config.HTTPPortMin,
+				HTTPPortMax: b.config.HTTPPortMax,
+			},
 			&common.StepRun{
 				Config:   &b.config.RunConfig,
 				SetOrder: false,

--- a/clone/builder.go
+++ b/clone/builder.go
@@ -56,6 +56,11 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 				Config:   &b.config.RunConfig,
 				SetOrder: false,
 			},
+			&common.StepBootCommand{
+				Config: &b.config.BootConfig,
+				Ctx:    b.config.ctx,
+				VMName: b.config.VMName,
+			},
 			&common.StepWaitForIp{
 				Config: &b.config.WaitIpConfig,
 			},

--- a/clone/config.go
+++ b/clone/config.go
@@ -11,6 +11,7 @@ import (
 
 type Config struct {
 	packerCommon.PackerConfig `mapstructure:",squash"`
+	packerCommon.HTTPConfig   `mapstructure:",squash"`
 
 	common.ConnectConfig      `mapstructure:",squash"`
 	CloneConfig               `mapstructure:",squash"`
@@ -50,6 +51,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	errs = packer.MultiErrorAppend(errs, c.CloneConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.LocationConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
+	errs = packer.MultiErrorAppend(errs, c.HTTPConfig.Prepare(&c.ctx)...)
 
 	errs = packer.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare()...)

--- a/clone/config.go
+++ b/clone/config.go
@@ -52,6 +52,7 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	errs = packer.MultiErrorAppend(errs, c.HardwareConfig.Prepare()...)
 
 	errs = packer.MultiErrorAppend(errs, c.WaitIpConfig.Prepare()...)
+	errs = packer.MultiErrorAppend(errs, c.BootConfig.Prepare()...)
 	errs = packer.MultiErrorAppend(errs, c.Comm.Prepare(&c.ctx)...)
 	errs = packer.MultiErrorAppend(errs, c.ShutdownConfig.Prepare()...)
 

--- a/clone/config.go
+++ b/clone/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	common.ConfigParamsConfig `mapstructure:",squash"`
 
 	common.RunConfig      `mapstructure:",squash"`
+	common.BootConfig     `mapstructure:",squash"`
 	common.WaitIpConfig   `mapstructure:",squash"`
 	Comm                  communicator.Config `mapstructure:",squash"`
 	common.ShutdownConfig `mapstructure:",squash"`
@@ -34,6 +35,11 @@ func NewConfig(raws ...interface{}) (*Config, []string, error) {
 	err := config.Decode(c, &config.DecodeOpts{
 		Interpolate:        true,
 		InterpolateContext: &c.ctx,
+		InterpolateFilter: &interpolate.RenderFilter{
+			Exclude: []string{
+				"boot_command",
+			},
+		},
 	}, raws...)
 	if err != nil {
 		return nil, nil, err

--- a/common/step_boot_command.go
+++ b/common/step_boot_command.go
@@ -1,4 +1,4 @@
-package iso
+package common
 
 import (
 	"context"

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,3 @@ require (
 )
 
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
-

--- a/iso/builder.go
+++ b/iso/builder.go
@@ -94,7 +94,7 @@ func (b *Builder) Run(ctx context.Context, ui packer.Ui, hook packer.Hook) (pack
 				Config:   &b.config.RunConfig,
 				SetOrder: true,
 			},
-			&StepBootCommand{
+			&common.StepBootCommand{
 				Config: &b.config.BootConfig,
 				Ctx:    b.config.ctx,
 				VMName: b.config.VMName,

--- a/iso/config.go
+++ b/iso/config.go
@@ -24,7 +24,7 @@ type Config struct {
 	CDRomConfig         `mapstructure:",squash"`
 	FloppyConfig        `mapstructure:",squash"`
 	common.RunConfig    `mapstructure:",squash"`
-	BootConfig          `mapstructure:",squash"`
+	common.BootConfig   `mapstructure:",squash"`
 	common.WaitIpConfig `mapstructure:",squash"`
 	Comm                communicator.Config `mapstructure:",squash"`
 


### PR DESCRIPTION
This adds the `boot_command` functionality (and therefore also the HTTP capability) to the clone builder.

Closes #111 (our use-case is identical) 

[Test build](https://github.com/ASML-Labs/packer-builder-vsphere/releases/tag/2.4-asml1)